### PR TITLE
This commit continues my work on converting the JRadius `core` module…

### DIFF
--- a/core-dotnet/config/Configuration.cs
+++ b/core-dotnet/config/Configuration.cs
@@ -1,7 +1,11 @@
+using JRadius.Core.Handler.Chain;
+using JRadius.Core.Session;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Reflection;
 using System.Xml.Linq;
 
 namespace JRadius.Core.Config
@@ -16,12 +20,20 @@ namespace JRadius.Core.Config
         private static int _timeoutSeconds;
         private static FileInfo _configFile;
         private static Dictionary<string, ListenerConfigurationItem> _listeners = new Dictionary<string, ListenerConfigurationItem>();
-        private static Dictionary<string, object> _packetHandlers = new Dictionary<string, object>(); // TODO: Replace object with PacketHandlerConfigurationItem
-        private static Dictionary<string, object> _eventHandlers = new Dictionary<string, object>(); // TODO: Replace object with HandlerConfigurationItem
+        private static Dictionary<string, PacketHandlerConfigurationItem> _packetHandlers = new Dictionary<string, PacketHandlerConfigurationItem>();
+        private static Dictionary<string, HandlerConfigurationItem> _eventHandlers = new Dictionary<string, HandlerConfigurationItem>();
         private static Dictionary<string, DictionaryConfigurationItem> _dictionaries = new Dictionary<string, DictionaryConfigurationItem>();
-        // private static JRConfigParser parser = new JRConfigParser(); // TODO: Implement JRConfigParser
-        // private static CatalogFactory factory = CatalogFactory.getInstance(); // TODO: Find replacement for commons-chain
-        private static object _logConfig; // TODO: Replace object with LogConfigurationItem
+        private static JRConfigParser _parser = new JRConfigParser();
+        private static CatalogFactory _factory = CatalogFactory.GetInstance();
+        private static LogConfigurationItem _logConfig;
+
+        private const string SESSION_MANAGER_KEY = "session-manager";
+        private const string REALM_MANAGER_KEY = "realm-manager";
+        private const string REQUESTER_KEY = "requester";
+        private const string KEY_PROVIDER_KEY = "key-provider";
+        private const string SESSION_FACTORY_KEY = "session-factory";
+        private const string REALM_FACTORY_KEY = "realm-factory";
+
 
         public static void Initialize(Stream input, ILoggerFactory loggerFactory)
         {
@@ -31,14 +43,183 @@ namespace JRadius.Core.Config
 
             _logger.LogInformation("Configuring JRadius Server....");
 
-            // SetLogConfig();
-            // SetGeneralOptions();
-            // SetRealmManagerConfig();
-            // SetSessionManagerConfig();
-            // SetDictionaryConfigs();
-            // SetPacketHandlersConfigs();
-            // SetEventHandlersConfigs();
-            // SetListenerConfigs();
+            SetLogConfig();
+            SetGeneralOptions();
+            SetRealmManagerConfig();
+            SetSessionManagerConfig();
+            SetDictionaryConfigs();
+            SetPacketHandlersConfigs();
+            SetEventHandlersConfigs();
+            SetListenerConfigs();
+        }
+
+        private static void SetGeneralOptions()
+        {
+            bool.TryParse(_root.Element("debug")?.Value, out _debug);
+            int.TryParse(_root.Element("timeout")?.Value, out _timeoutSeconds);
+
+            var children = _root.Elements("chain-catalog");
+            foreach (var node in children)
+            {
+                var catalogURL = node.Element("name")?.Value;
+                if (catalogURL != null)
+                {
+                    _logger.LogDebug($"Loading Chains URL: {catalogURL}");
+                    try
+                    {
+                        using (var stream = new FileStream(catalogURL, FileMode.Open, FileAccess.Read))
+                        {
+                            var catalog = _parser.Parse(stream);
+                            _factory.AddCatalog(catalogURL, catalog);
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        _logger.LogError(e, $"Error loading catalog chain: {catalogURL}");
+                    }
+                }
+            }
+        }
+
+        private static void SetLogConfig()
+        {
+            var children = _root.Elements(LogConfigurationItem.XML_KEY);
+            foreach (var node in children)
+            {
+                if (_logConfig != null)
+                {
+                    _logger.LogWarning("A RadiusLogger is already configured, skipping configuration");
+                    return;
+                }
+                _logConfig = new LogConfigurationItem(node);
+                // TODO: Setup the new logger
+            }
+        }
+
+        private static void SetDictionaryConfigs()
+        {
+            var children = _root.Elements(DictionaryConfigurationItem.XML_KEY);
+            foreach (var node in children)
+            {
+                var item = new DictionaryConfigurationItem(node);
+                _dictionaries[item.Name] = item;
+            }
+        }
+
+        private static void SetListenerConfigs()
+        {
+            var list = _root.Elements(ListenerConfigurationItem.XML_LIST_KEY);
+            foreach (var l in list)
+            {
+                var children = l.Elements(ListenerConfigurationItem.XML_KEY);
+                foreach (var node in children)
+                {
+                    var item = new ListenerConfigurationItem(node);
+                    _listeners[item.Name] = item;
+                }
+            }
+        }
+
+        private static void SetPacketHandlersConfigs()
+        {
+            var list = _root.Elements(PacketHandlerConfigurationItem.XML_LIST_KEY);
+            foreach (var l in list)
+            {
+                var children = l.Elements(PacketHandlerConfigurationItem.XML_KEY);
+                foreach (var node in children)
+                {
+                    var item = new PacketHandlerConfigurationItem(node);
+                    _packetHandlers[item.Name] = item;
+                }
+            }
+        }
+
+        private static void SetEventHandlersConfigs()
+        {
+            var list = _root.Elements(HandlerConfigurationItem.XML_LIST_KEY);
+            foreach (var l in list)
+            {
+                var children = l.Elements(HandlerConfigurationItem.XML_KEY);
+                foreach (var node in children)
+                {
+                    var item = new HandlerConfigurationItem(node);
+                    _eventHandlers[item.Name] = item;
+                }
+            }
+        }
+
+        private static void SetSessionManagerConfig()
+        {
+            _logger.LogInformation("Initializing session manager");
+            var list = _root.Elements(SESSION_MANAGER_KEY);
+            foreach (var node in list)
+            {
+                var clazz = node.Element("class")?.Value;
+                var requester = node.Element(REQUESTER_KEY)?.Value;
+                var keyProvider = node.Element(KEY_PROVIDER_KEY)?.Value;
+                var sessionFactory = node.Element(SESSION_FACTORY_KEY)?.Value;
+
+                if (clazz != null)
+                {
+                    try
+                    {
+                        _logger.LogDebug($"Session Manager ({requester}): {clazz}");
+                        var manager = (JRadiusSessionManager)GetBean(clazz);
+                        JRadiusSessionManager.SetManager(requester, manager);
+                    }
+                    catch (Exception e)
+                    {
+                        _logger.LogError(e, e.Message);
+                    }
+                }
+
+                if (keyProvider != null)
+                {
+                    try
+                    {
+                        _logger.LogDebug($"Session Key Provider ({requester}): {keyProvider}");
+                        var provider = (ISessionKeyProvider)GetBean(keyProvider);
+                        JRadiusSessionManager.GetManager(requester).SetSessionKeyProvider(requester, provider);
+                    }
+                    catch (Exception e)
+                    {
+                        _logger.LogError(e, e.Message);
+                    }
+                }
+
+                if (sessionFactory != null)
+                {
+                    try
+                    {
+                        _logger.LogDebug($"Session Factory ({requester}): {sessionFactory}");
+                        var factory = (ISessionFactory)GetBean(sessionFactory);
+                        // factory.SetConfig(node); // TODO: ISessionFactory needs a SetConfig method
+                        JRadiusSessionManager.GetManager(requester).SetSessionFactory(requester, factory);
+                    }
+                    catch (Exception e)
+                    {
+                        _logger.LogError(e, e.Message);
+                    }
+                }
+            }
+        }
+
+        private static void SetRealmManagerConfig()
+        {
+            _logger.LogInformation("Initializing realm manager");
+            var list = _root.Elements(REALM_MANAGER_KEY);
+            foreach (var node in list)
+            {
+                // TODO: Implement this method. Requires GetBean and realm classes.
+            }
+        }
+
+        public static object GetBean(string name)
+        {
+            if (name == null) return null;
+            Type type = Type.GetType(name);
+            if (type == null) return null;
+            return Activator.CreateInstance(type);
         }
 
         public static bool IsDebug()
@@ -52,12 +233,12 @@ namespace JRadius.Core.Config
             return _configFile.DirectoryName;
         }
 
-        public static ICollection<object> GetPacketHandlers()
+        public static ICollection<PacketHandlerConfigurationItem> GetPacketHandlers()
         {
             return _packetHandlers.Values;
         }
 
-        public static ICollection<object> GetEventHandlers()
+        public static ICollection<HandlerConfigurationItem> GetEventHandlers()
         {
             return _eventHandlers.Values;
         }

--- a/core-dotnet/config/ConfigurationItem.cs
+++ b/core-dotnet/config/ConfigurationItem.cs
@@ -1,0 +1,90 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace JRadius.Core.Config
+{
+    public abstract class ConfigurationItem
+    {
+        protected XElement _root;
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public string ClassName { get; set; }
+        public Dictionary<string, string> Properties { get; set; }
+
+        public ConfigurationItem(string name)
+        {
+            Name = name;
+        }
+
+        public ConfigurationItem(string name, string className)
+        {
+            Name = name;
+            ClassName = className;
+        }
+
+        public ConfigurationItem(XElement node)
+        {
+            _root = node;
+            Name = GetConfigString("name");
+            Description = GetConfigString("description");
+            ClassName = GetConfigString("class");
+            SetProperties();
+        }
+
+        protected void SetProperties()
+        {
+            Properties = GetPropertiesFromConfig(_root);
+        }
+
+        public static Dictionary<string, string> GetPropertiesFromConfig(XElement root)
+        {
+            var map = new Dictionary<string, string>();
+            var properties = root.Elements("property");
+            foreach (var property in properties)
+            {
+                var name = property.Element("name")?.Value;
+                var value = property.Element("value")?.Value;
+                if (name != null)
+                {
+                    map[name] = value;
+                }
+            }
+            return map;
+        }
+
+        public XElement GetRoot()
+        {
+            return _root;
+        }
+
+        protected string GetConfigString(string elementName)
+        {
+            return _root.Element(elementName)?.Value;
+        }
+
+        protected int GetConfigInt(string elementName)
+        {
+            var value = GetConfigString(elementName);
+            int.TryParse(value, out int result);
+            return result;
+        }
+
+        protected bool GetConfigBoolean(string elementName)
+        {
+            var value = GetConfigString(elementName);
+            bool.TryParse(value, out bool result);
+            return result;
+        }
+
+        public virtual string XmlKey()
+        {
+            return "no such key";
+        }
+
+        public override string ToString()
+        {
+            return $"{Name} [{ClassName}]: {Description} -- {string.Join(", ", Properties.Select(p => $"{p.Key}={p.Value}"))}";
+        }
+    }
+}

--- a/core-dotnet/config/HandlerConfigurationItem.cs
+++ b/core-dotnet/config/HandlerConfigurationItem.cs
@@ -1,0 +1,113 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace JRadius.Core.Config
+{
+    public class HandlerConfigurationItem : ConfigurationItem
+    {
+        public static readonly string XML_LIST_KEY = "event-handlers";
+        public static readonly string XML_KEY = "event-handler";
+
+        public static readonly string TYPE_KEY = "type";
+        public static readonly string SENDER_KEY = "sender";
+        public static readonly string HANDLER_KEY = "handler";
+        public static readonly string CATALOG_KEY = "catalog";
+
+        private List<string> _possibleTypes;
+        public List<string> HandleTypes { get; set; }
+        public List<string> Senders { get; set; }
+
+        public string HandlerName { get; set; }
+        public string CatalogName { get; set; }
+
+        public HandlerConfigurationItem(string name)
+            : base(name)
+        {
+        }
+
+        public HandlerConfigurationItem(string name, string className)
+            : base(name, className)
+        {
+        }
+
+        public HandlerConfigurationItem(XElement node)
+            : base(node)
+        {
+            _possibleTypes = node.Elements("handle").Elements("type").Select(t => t.Value).ToList();
+            var type = GetConfigString(TYPE_KEY);
+            var sender = GetConfigString(SENDER_KEY);
+            HandlerName = GetConfigString(HANDLER_KEY);
+            CatalogName = GetConfigString(CATALOG_KEY);
+            SetSenders(sender);
+            SetHandleTypes(type);
+        }
+
+        public void SetHandleTypes(string handleTypes)
+        {
+            var list = new List<string>();
+            if (handleTypes == null) handleTypes = "";
+            var types = handleTypes.Split(',').Select(s => s.Trim()).ToArray();
+
+            if (types != null)
+            {
+                foreach (var t in types)
+                {
+                    if (t.Length > 0)
+                    {
+                        if (_possibleTypes == null ||
+                            !_possibleTypes.Any() ||
+                            _possibleTypes.Contains(t))
+                        {
+                            list.Add(t);
+                        }
+                    }
+                }
+            }
+            HandleTypes = list;
+        }
+
+        public void SetSenders(string sender)
+        {
+            var list = new List<string>();
+            if (sender == null) sender = "";
+            var types = sender.Split(',').Select(s => s.Trim()).ToArray();
+
+            if (types != null)
+            {
+                foreach (var t in types)
+                {
+                    if (t.Length > 0)
+                    {
+                        list.Add(t);
+                    }
+                }
+            }
+            Senders = list;
+        }
+
+        public List<string> GetPossibleTypes()
+        {
+            return _possibleTypes;
+        }
+
+        public void SetPossibleTypes(List<string> possibleTypes)
+        {
+            _possibleTypes = possibleTypes;
+        }
+
+        public bool HandlesType(string type)
+        {
+            if (!HandleTypes.Any()) return true;
+            if (HandleTypes.Contains(type)) return true;
+            return false;
+        }
+
+        public bool HandlesSender(object sender)
+        {
+            if (!Senders.Any()) return true;
+            if (Senders.Contains(sender.ToString())) return true;
+            return false;
+        }
+    }
+}

--- a/core-dotnet/config/ListenerConfigurationItem.cs
+++ b/core-dotnet/config/ListenerConfigurationItem.cs
@@ -1,14 +1,58 @@
 using System.Collections.Generic;
-using net.jradius.core.handler;
+using System.Xml.Linq;
 
-namespace net.jradius.core.config
+namespace JRadius.Core.Config
 {
-    public class ListenerConfigurationItem
+    public class ListenerConfigurationItem : ConfigurationItem
     {
-        public string ClassName { get; set; }
-        public int NumberOfThreads { get; set; }
-        public string ProcessorClassName { get; set; }
-        public List<JRCommand> RequestHandlers { get; set; }
-        public List<JRCommand> EventHandlers { get; set; }
+        public static string XML_LIST_KEY = "listeners";
+        public static string XML_KEY = "listener";
+
+        private List<object> _requestHandlers; // TODO: Replace object with JRCommand
+        private List<object> _eventHandlers; // TODO: Replace object with JRCommand
+        private string _processorClassName;
+        private int _numberOfThreads;
+
+        private static readonly string PROC_CLASS_KEY = "processor-class";
+        private static readonly string PROC_THREADS_KEY = "processor-threads";
+
+        public ListenerConfigurationItem(XElement node)
+            : base(node)
+        {
+            _processorClassName = GetConfigString(PROC_CLASS_KEY);
+            _numberOfThreads = GetConfigInt(PROC_THREADS_KEY);
+            if (_numberOfThreads == 0)
+            {
+                _numberOfThreads = 1;
+            }
+
+            // TODO: Implement the handler loading logic here.
+            // This requires the chain of responsibility pattern and the getBean method to be implemented.
+        }
+
+        public List<object> GetRequestHandlers()
+        {
+            return _requestHandlers;
+        }
+
+        public List<object> GetEventHandlers()
+        {
+            return _eventHandlers;
+        }
+
+        public int GetNumberOfThreads()
+        {
+            return _numberOfThreads;
+        }
+
+        public string GetProcessorClassName()
+        {
+            return _processorClassName;
+        }
+
+        public override string XmlKey()
+        {
+            return XML_KEY;
+        }
     }
 }

--- a/core-dotnet/config/LogConfigurationItem.cs
+++ b/core-dotnet/config/LogConfigurationItem.cs
@@ -2,11 +2,11 @@ using System.Xml.Linq;
 
 namespace JRadius.Core.Config
 {
-    public class DictionaryConfigurationItem : ConfigurationItem
+    public class LogConfigurationItem : ConfigurationItem
     {
-        public static string XML_KEY = "dictionary";
+        public static string XML_KEY = "radius-logger";
 
-        public DictionaryConfigurationItem(XElement node)
+        public LogConfigurationItem(XElement node)
             : base(node)
         {
         }

--- a/core-dotnet/config/PacketHandlerConfigurationItem.cs
+++ b/core-dotnet/config/PacketHandlerConfigurationItem.cs
@@ -1,0 +1,31 @@
+using System.Xml.Linq;
+
+namespace JRadius.Core.Config
+{
+    public class PacketHandlerConfigurationItem : HandlerConfigurationItem
+    {
+        public static readonly string XML_LIST_KEY = "packet-handlers";
+        public static readonly new string XML_KEY = "packet-handler";
+        public static readonly string XML_KEY_ALT = "request-handler";
+
+        public PacketHandlerConfigurationItem(string name)
+            : base(name)
+        {
+        }
+
+        public PacketHandlerConfigurationItem(string name, string className)
+            : base(name, className)
+        {
+        }
+
+        public PacketHandlerConfigurationItem(XElement node)
+            : base(node)
+        {
+        }
+
+        public override string XmlKey()
+        {
+            return XML_KEY;
+        }
+    }
+}

--- a/core-dotnet/handler/JRCommand.cs
+++ b/core-dotnet/handler/JRCommand.cs
@@ -1,6 +1,0 @@
-namespace net.jradius.core.handler
-{
-    public interface JRCommand
-    {
-    }
-}

--- a/core-dotnet/handler/chain/CatalogBase.cs
+++ b/core-dotnet/handler/chain/CatalogBase.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+
+namespace JRadius.Core.Handler.Chain
+{
+    public class CatalogBase
+    {
+        protected Dictionary<string, ICommand> _commands = new Dictionary<string, ICommand>();
+
+        public void AddCommand(string name, ICommand command)
+        {
+            _commands[name] = command;
+        }
+
+        public ICommand GetCommand(string name)
+        {
+            _commands.TryGetValue(name, out ICommand command);
+            return command;
+        }
+    }
+}

--- a/core-dotnet/handler/chain/CatalogFactory.cs
+++ b/core-dotnet/handler/chain/CatalogFactory.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+
+namespace JRadius.Core.Handler.Chain
+{
+    public class CatalogFactory
+    {
+        private static CatalogFactory _instance = new CatalogFactory();
+        private Dictionary<string, CatalogBase> _catalogs = new Dictionary<string, CatalogBase>();
+        private CatalogBase _defaultCatalog;
+
+        public static CatalogFactory GetInstance()
+        {
+            return _instance;
+        }
+
+        public CatalogBase GetCatalog(string name = null)
+        {
+            if (name == null)
+            {
+                return _defaultCatalog;
+            }
+            _catalogs.TryGetValue(name, out CatalogBase catalog);
+            return catalog;
+        }
+
+        public void AddCatalog(string name, CatalogBase catalog)
+        {
+            if (_defaultCatalog == null)
+            {
+                _defaultCatalog = catalog;
+            }
+            _catalogs[name] = catalog;
+        }
+    }
+}

--- a/core-dotnet/handler/chain/ChainBase.cs
+++ b/core-dotnet/handler/chain/ChainBase.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+
+namespace JRadius.Core.Handler.Chain
+{
+    public class ChainBase : ICommand
+    {
+        protected List<ICommand> _commands = new List<ICommand>();
+
+        public void AddCommand(ICommand command)
+        {
+            _commands.Add(command);
+        }
+
+        public virtual bool Execute(IContext context)
+        {
+            foreach (var command in _commands)
+            {
+                if (command.Execute(context))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+}

--- a/core-dotnet/handler/chain/ICommand.cs
+++ b/core-dotnet/handler/chain/ICommand.cs
@@ -1,0 +1,15 @@
+namespace JRadius.Core.Handler.Chain
+{
+    public interface ICommand
+    {
+        /// <summary>
+        /// Execute a unit of processing work to be performed.
+        /// </summary>
+        /// <param name="context">The context for this command.</param>
+        /// <returns>
+        /// Return true if processing of this command completes, and processing of the chain should be terminated.
+        /// Return false if processing of this command completes, and processing of the chain should continue.
+        /// </returns>
+        bool Execute(IContext context);
+    }
+}

--- a/core-dotnet/handler/chain/IContext.cs
+++ b/core-dotnet/handler/chain/IContext.cs
@@ -1,0 +1,9 @@
+namespace JRadius.Core.Handler.Chain
+{
+    public interface IContext
+    {
+        // This is a marker interface for now.
+        // The original commons-chain Context is a map-like object.
+        // I will add members as needed.
+    }
+}

--- a/core-dotnet/handler/chain/IJRCommand.cs
+++ b/core-dotnet/handler/chain/IJRCommand.cs
@@ -1,0 +1,32 @@
+using JRadius.Core.Config;
+using JRadius.Core.Server;
+
+namespace JRadius.Core.Handler.Chain
+{
+    /// <summary>
+    /// The JRadius Command Interface for the Chain of Responsibility pattern.
+    /// This is the foundation of all handlers within JRadius - which
+    /// can be single command, or chains of commands.
+    /// </summary>
+    public interface IJRCommand : ICommand
+    {
+        /// <summary>
+        /// Set the ConfigurationItem of this handler. All JRadius handlers
+        /// have an associated HandlerConfigurationItem associated with it.
+        /// </summary>
+        /// <param name="cfg">The HandlerConfigurationItem to be set</param>
+        void SetConfig(ConfigurationItem cfg);
+
+        /// <summary>
+        /// Tests whether or not this handler handles the given JRadiusEvent.
+        /// </summary>
+        /// <param name="event">The JRadiusEvent (or JRadiusRequest) to be checked</param>
+        /// <returns>Returns true if this handler should handle the given event</returns>
+        bool DoesHandle(JRadiusEvent @event);
+
+        /// <summary>
+        /// The name of the handler (as defined in the configuration)
+        /// </summary>
+        string Name { get; }
+    }
+}

--- a/core-dotnet/handler/chain/JRCatalogBase.cs
+++ b/core-dotnet/handler/chain/JRCatalogBase.cs
@@ -1,0 +1,9 @@
+namespace JRadius.Core.Handler.Chain
+{
+    public class JRCatalogBase : CatalogBase
+    {
+        public JRCatalogBase()
+        {
+        }
+    }
+}

--- a/core-dotnet/handler/chain/JRChainBase.cs
+++ b/core-dotnet/handler/chain/JRChainBase.cs
@@ -1,0 +1,50 @@
+using JRadius.Core.Config;
+using JRadius.Core.Server;
+using Microsoft.Extensions.Logging;
+
+namespace JRadius.Core.Handler.Chain
+{
+    public class JRChainBase : ChainBase, IJRCommand
+    {
+        private readonly ILogger<JRChainBase> _logger;
+        protected HandlerConfigurationItem _config;
+
+        public JRChainBase(ILogger<JRChainBase> logger)
+        {
+            _logger = logger;
+        }
+
+        public string Name { get; set; }
+
+        public void SetConfig(ConfigurationItem cfg)
+        {
+            _config = (HandlerConfigurationItem)cfg;
+        }
+
+        public bool DoesHandle(JRadiusEvent @event)
+        {
+            if (_config == null) return true;
+            return (_config.HandlesSender(@event.GetSender()) &&
+                    _config.HandlesType(@event.GetTypeString()));
+        }
+
+        public override bool Execute(IContext context)
+        {
+            _logger.LogDebug($"Executing command: {Name}");
+            return base.Execute(context);
+        }
+
+        public void Initialize()
+        {
+            foreach (var command in _commands)
+            {
+                // In a real DI scenario, we would resolve dependencies here.
+                // For now, we assume commands are already configured.
+                if (command is JRChainBase chain)
+                {
+                    chain.Initialize();
+                }
+            }
+        }
+    }
+}

--- a/core-dotnet/handler/chain/JRConfigParser.cs
+++ b/core-dotnet/handler/chain/JRConfigParser.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Xml.Linq;
+
+namespace JRadius.Core.Handler.Chain
+{
+    public class JRConfigParser
+    {
+        public JRCatalogBase Parse(Stream stream)
+        {
+            var catalog = new JRCatalogBase();
+            var doc = XDocument.Load(stream);
+
+            foreach (var chainElement in doc.Root.Elements("chain"))
+            {
+                var chain = new JRChainBase(null); // TODO: Inject logger
+                var chainName = chainElement.Attribute("name")?.Value;
+                chain.Name = chainName;
+
+                foreach (var commandElement in chainElement.Elements())
+                {
+                    var className = commandElement.Attribute("className")?.Value;
+                    if (className != null)
+                    {
+                        var command = (ICommand)Activator.CreateInstance(Type.GetType(className));
+                        chain.AddCommand(command);
+                    }
+                }
+                catalog.AddCommand(chainName, chain);
+            }
+            return catalog;
+        }
+    }
+}

--- a/core-dotnet/realm/IRealmFactory.cs
+++ b/core-dotnet/realm/IRealmFactory.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using System.Xml.Linq;
+
+namespace JRadius.Core.Realm
+{
+    public interface IRealmFactory
+    {
+        JRadiusRealm GetRealm(string realmName);
+        ICollection<JRadiusRealm> GetRealms();
+        void SetConfig(XElement root);
+    }
+}

--- a/core-dotnet/realm/JRadiusRealm.cs
+++ b/core-dotnet/realm/JRadiusRealm.cs
@@ -1,0 +1,15 @@
+namespace JRadius.Core.Realm
+{
+    public class JRadiusRealm
+    {
+        public bool IsLocal { get; set; }
+        public int AcctPort { get; set; }
+        public int AuthPort { get; set; }
+        public string Realm { get; set; }
+        public string Server { get; set; }
+        public string SharedSecret { get; set; }
+        public int Strip { get; set; }
+        public string Source { get; set; }
+        public int TimeStamp { get; set; }
+    }
+}

--- a/core-dotnet/session/ISessionFactory.cs
+++ b/core-dotnet/session/ISessionFactory.cs
@@ -1,0 +1,15 @@
+using JRadius.Core.Log;
+using JRadius.Core.Server;
+using System.Xml.Linq;
+
+namespace JRadius.Core.Session
+{
+    public interface ISessionFactory
+    {
+        JRadiusSession GetSession(JRadiusRequest request, object key);
+        JRadiusSession NewSession(JRadiusRequest request);
+        JRadiusLogEntry NewSessionLogEntry(JRadiusEvent @event, JRadiusSession session, string packetId);
+        void SetConfig(XElement root);
+        string GetConfigValue(string name);
+    }
+}

--- a/core-dotnet/session/ISessionKeyProvider.cs
+++ b/core-dotnet/session/ISessionKeyProvider.cs
@@ -1,0 +1,11 @@
+using JRadius.Core.Server;
+
+namespace JRadius.Core.Session
+{
+    public interface ISessionKeyProvider
+    {
+        object GetClassKey(JRadiusRequest request);
+        object GetAppSessionKey(JRadiusRequest request);
+        object GetRequestSessionKey(JRadiusRequest request);
+    }
+}

--- a/core-dotnet/session/JRadiusSessionManager.cs
+++ b/core-dotnet/session/JRadiusSessionManager.cs
@@ -1,10 +1,139 @@
-namespace net.jradius.core.session
+using JRadius.Core.Server;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+
+namespace JRadius.Core.Session
 {
-    public static class JRadiusSessionManager
+    public class JRadiusSessionManager : IDisposable
     {
+        private static JRadiusSessionManager _defaultManager;
+        private static Dictionary<string, JRadiusSessionManager> _managers = new Dictionary<string, JRadiusSessionManager>();
+
+        private Dictionary<string, ISessionKeyProvider> _providers = new Dictionary<string, ISessionKeyProvider>();
+        private Dictionary<string, ISessionFactory> _factories = new Dictionary<string, ISessionFactory>();
+
+        private int _minInterimInterval = 300;
+        private int _maxInactiveInterval = 2100;
+
+        private IMemoryCache _sessionCache;
+        private IMemoryCache _logCache;
+
+        private EventDispatcher _eventDispatcher;
+        private readonly ILogger<JRadiusSessionManager> _logger;
+
+        public JRadiusSessionManager(ILogger<JRadiusSessionManager> logger, IMemoryCache sessionCache, IMemoryCache logCache)
+        {
+            _logger = logger;
+            _sessionCache = sessionCache;
+            _logCache = logCache;
+            Initialize();
+        }
+
+        private void Initialize()
+        {
+            // In a real implementation, we would use reflection to find and instantiate
+            // the default providers and factories, or use dependency injection.
+            // For now, we'll leave this empty.
+        }
+
+        public static JRadiusSessionManager GetManager(object name)
+        {
+            JRadiusSessionManager manager = null;
+            if (name != null)
+            {
+                _managers.TryGetValue(name.ToString(), out manager);
+            }
+
+            if (manager == null)
+            {
+                if (_defaultManager == null)
+                {
+                    // This is not ideal. In a real application, the default manager should be
+                    // configured and created by the application's startup code.
+                    // _defaultManager = new JRadiusSessionManager( ... );
+                }
+                manager = _defaultManager;
+            }
+            return manager;
+        }
+
+        public static JRadiusSessionManager SetManager(string name, JRadiusSessionManager manager)
+        {
+            if (name != null)
+            {
+                _managers[name] = manager;
+            }
+            else
+            {
+                _defaultManager = manager;
+            }
+            return manager;
+        }
+
         public static void ShutdownManagers()
         {
-            // In a real implementation, this would shut down any active session managers.
+            if (_defaultManager != null)
+            {
+                _defaultManager.Dispose();
+            }
+
+            foreach (var manager in _managers.Values)
+            {
+                manager.Dispose();
+            }
+        }
+
+        public void Dispose()
+        {
+            _sessionCache.Dispose();
+            _logCache.Dispose();
+        }
+
+        public void SetSessionKeyProvider(string name, ISessionKeyProvider provider)
+        {
+            _providers[name] = provider;
+        }
+
+        public void SetSessionFactory(string name, ISessionFactory factory)
+        {
+            _factories[name] = factory;
+        }
+
+        public ISessionKeyProvider GetSessionKeyProvider(object name)
+        {
+            _providers.TryGetValue(name?.ToString(), out ISessionKeyProvider provider);
+            if (provider == null && name != null)
+            {
+                _providers.TryGetValue(null, out provider);
+            }
+            return provider;
+        }
+
+        public ISessionFactory GetSessionFactory(object name)
+        {
+            _factories.TryGetValue(name?.ToString(), out ISessionFactory factory);
+            if (factory == null && name != null)
+            {
+                _factories.TryGetValue(null, out factory);
+            }
+            return factory;
+        }
+
+        public JRadiusSession GetSession(JRadiusRequest request)
+        {
+            // TODO: Implement the session retrieval logic.
+            return null;
+        }
+
+        public void RemoveSession(JRadiusSession session)
+        {
+            if (session != null)
+            {
+                _sessionCache.Remove(session.GetJRadiusKey());
+                _sessionCache.Remove(session.GetSessionKey());
+            }
         }
     }
 }


### PR DESCRIPTION
… from Java to C# .NET 8. In it, I've introduced a significant portion of the C# infrastructure required to replicate the functionality of the original Java application.

I've made the following changes:

1.  **Configuration Framework:**
    *   I implemented a C# version of the `Configuration` class to parse the XML configuration file.
    *   I converted the various `ConfigurationItem` classes (`Dictionary`, `Listener`, `PacketHandler`, `EventHandler`, `Log`) to C#.

2.  **Chain of Responsibility Pattern:**
    *   To replace the `apache-commons-chain` dependency, I created a new set of C# classes and interfaces (`ICommand`, `IJRCommand`, `ChainBase`, `CatalogBase`, etc.).
    *   I added a skeleton `JRConfigParser` to handle the parsing of chain configuration files.

3.  **Session and Realm Management:**
    *   I converted the interfaces and classes for session management (`ISessionKeyProvider`, `ISessionFactory`, `JRadiusSessionManager`). My implementation of `JRadiusSessionManager` uses `Microsoft.Extensions.Caching.Memory` as a replacement for `ehcache`.
    *   I also converted the initial classes for realm management (`IRealmFactory`, `JRadiusRealm`).

**Work In Progress:**
This conversion is a large undertaking and is still in progress. The code I'm providing contains several `TODO` comments marking areas that require further implementation. Specifically, the logic for instantiating objects (replacing Spring's `getBean`), the full implementation of the chain of responsibility execution, and the detailed logic within the session and realm managers are the next major steps. I was in the process of working through these complex, interdependent components when you requested an update.