### PR TITLE
I've continued the conversion of your JRadius library from Java to C#…

### DIFF
--- a/extended-dotnet/CombinedHash.cs
+++ b/extended-dotnet/CombinedHash.cs
@@ -1,0 +1,60 @@
+using Org.BouncyCastle.Crypto;
+using Org.BouncyCastle.Crypto.Digests;
+
+namespace JRadius.Extended.Tls
+{
+    public class CombinedHash : IDigest
+    {
+        private readonly MD5Digest _md5;
+        private readonly Sha1Digest _sha1;
+
+        public CombinedHash()
+        {
+            _md5 = new MD5Digest();
+            _sha1 = new Sha1Digest();
+        }
+
+        public CombinedHash(CombinedHash t)
+        {
+            _md5 = new MD5Digest(t._md5);
+            _sha1 = new Sha1Digest(t._sha1);
+        }
+
+        public string AlgorithmName => _md5.AlgorithmName + " and " + _sha1.AlgorithmName + " for TLS 1.0";
+
+        public int GetDigestSize()
+        {
+            return 16 + 20;
+        }
+
+        public void Update(byte input)
+        {
+            _md5.Update(input);
+            _sha1.Update(input);
+        }
+
+        public void BlockUpdate(byte[] input, int inOff, int len)
+        {
+            _md5.BlockUpdate(input, inOff, len);
+            _sha1.BlockUpdate(input, inOff, len);
+        }
+
+        public int DoFinal(byte[] output, int outOff)
+        {
+            int i1 = _md5.DoFinal(output, outOff);
+            int i2 = _sha1.DoFinal(output, outOff + 16);
+            return i1 + i2;
+        }
+
+        public void Reset()
+        {
+            _md5.Reset();
+            _sha1.Reset();
+        }
+
+        public int GetByteLength()
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}

--- a/extended-dotnet/ITlsSigner.cs
+++ b/extended-dotnet/ITlsSigner.cs
@@ -1,0 +1,10 @@
+using Org.BouncyCastle.Crypto;
+
+namespace JRadius.Extended.Tls
+{
+    public interface ITlsSigner
+    {
+        byte[] CalculateRawSignature(AsymmetricKeyParameter privateKey, byte[] md5andsha1);
+        ISigner CreateVerifyer(AsymmetricKeyParameter publicKey);
+    }
+}

--- a/extended-dotnet/TlsBlockCipher.cs
+++ b/extended-dotnet/TlsBlockCipher.cs
@@ -1,0 +1,159 @@
+using Org.BouncyCastle.Crypto;
+using Org.BouncyCastle.Crypto.Parameters;
+using System;
+using System.IO;
+using System.Security.Cryptography;
+
+namespace JRadius.Extended.Tls
+{
+    public class TlsBlockCipher : TlsCipher
+    {
+        private readonly TlsProtocolHandler _handler;
+        private readonly IBlockCipher _encryptCipher;
+        private readonly IBlockCipher _decryptCipher;
+        private readonly TlsMac _writeMac;
+        private readonly TlsMac _readMac;
+
+        public TlsBlockCipher(TlsProtocolHandler handler, IBlockCipher encryptCipher, IBlockCipher decryptCipher, IDigest writeDigest, IDigest readDigest, int cipherKeySize, SecurityParameters securityParameters)
+        {
+            _handler = handler;
+            _encryptCipher = encryptCipher;
+            _decryptCipher = decryptCipher;
+
+            int prfSize = (2 * cipherKeySize) + writeDigest.GetDigestSize() + readDigest.GetDigestSize() + encryptCipher.GetBlockSize() + decryptCipher.GetBlockSize();
+
+            byte[] keyBlock = TlsUtils.PRF(securityParameters.MasterSecret, "key expansion", TlsUtils.Concat(securityParameters.ServerRandom, securityParameters.ClientRandom), prfSize);
+
+            int offset = 0;
+
+            _writeMac = new TlsMac(writeDigest, keyBlock, offset, writeDigest.GetDigestSize());
+            offset += writeDigest.GetDigestSize();
+            _readMac = new TlsMac(readDigest, keyBlock, offset, readDigest.GetDigestSize());
+            offset += readDigest.GetDigestSize();
+
+            InitCipher(true, encryptCipher, keyBlock, cipherKeySize, offset, offset + (cipherKeySize * 2));
+            offset += cipherKeySize;
+            InitCipher(false, decryptCipher, keyBlock, cipherKeySize, offset, offset + cipherKeySize + encryptCipher.GetBlockSize());
+        }
+
+        private void InitCipher(bool forEncryption, IBlockCipher cipher, byte[] keyBlock, int keySize, int keyOffset, int ivOffset)
+        {
+            var keyParameter = new KeyParameter(keyBlock, keyOffset, keySize);
+            var parametersWithIv = new ParametersWithIV(keyParameter, keyBlock, ivOffset, cipher.GetBlockSize());
+            cipher.Init(forEncryption, parametersWithIv);
+        }
+
+        public byte[] EncodePlaintext(short type, byte[] plaintext, int offset, int len)
+        {
+            int blocksize = _encryptCipher.GetBlockSize();
+            int minPaddingSize = blocksize - ((len + _writeMac.GetSize() + 1) % blocksize);
+            int maxExtraPadBlocks = (255 - minPaddingSize) / blocksize;
+            int actualExtraPadBlocks = ChooseExtraPadBlocks(new SecureRandom(), maxExtraPadBlocks);
+            int paddingsize = minPaddingSize + (actualExtraPadBlocks * blocksize);
+
+            int totalsize = len + _writeMac.GetSize() + paddingsize + 1;
+            byte[] outbuf = new byte[totalsize];
+            Array.Copy(plaintext, offset, outbuf, 0, len);
+            byte[] mac = _writeMac.CalculateMac(type, plaintext, offset, len);
+            Array.Copy(mac, 0, outbuf, len, mac.Length);
+            int paddoffset = len + mac.Length;
+            for (int i = 0; i <= paddingsize; i++)
+            {
+                outbuf[i + paddoffset] = (byte)paddingsize;
+            }
+            for (int i = 0; i < totalsize; i += blocksize)
+            {
+                _encryptCipher.ProcessBlock(outbuf, i, outbuf, i);
+            }
+            return outbuf;
+        }
+
+        public byte[] DecodeCiphertext(short type, byte[] ciphertext, int offset, int len)
+        {
+            int minLength = _readMac.GetSize() + 1;
+            int blocksize = _decryptCipher.GetBlockSize();
+            bool decrypterror = false;
+
+            if (len < minLength)
+            {
+                _handler.FailWithError(TlsProtocolHandler.AL_fatal, TlsProtocolHandler.AP_decode_error);
+            }
+
+            if (len % blocksize != 0)
+            {
+                _handler.FailWithError(TlsProtocolHandler.AL_fatal, TlsProtocolHandler.AP_decryption_failed);
+            }
+
+            for (int i = 0; i < len; i += blocksize)
+            {
+                _decryptCipher.ProcessBlock(ciphertext, i + offset, ciphertext, i + offset);
+            }
+
+            int lastByteOffset = offset + len - 1;
+            byte paddingsizebyte = ciphertext[lastByteOffset];
+            int paddingsize = paddingsizebyte & 0xff;
+
+            int maxPaddingSize = len - minLength;
+            if (paddingsize > maxPaddingSize)
+            {
+                decrypterror = true;
+                paddingsize = 0;
+            }
+            else
+            {
+                byte diff = 0;
+                for (int i = lastByteOffset - paddingsize; i < lastByteOffset; ++i)
+                {
+                    diff |= (byte)(ciphertext[i] ^ paddingsizebyte);
+                }
+                if (diff != 0)
+                {
+                    decrypterror = true;
+                    paddingsize = 0;
+                }
+            }
+
+            int plaintextlength = len - minLength - paddingsize;
+            byte[] calculatedMac = _readMac.CalculateMac(type, ciphertext, offset, plaintextlength);
+            byte[] decryptedMac = new byte[calculatedMac.Length];
+            Array.Copy(ciphertext, offset + plaintextlength, decryptedMac, 0, calculatedMac.Length);
+
+            if (!Arrays.ConstantTimeAreEqual(calculatedMac, decryptedMac))
+            {
+                decrypterror = true;
+            }
+
+            if (decrypterror)
+            {
+                _handler.FailWithError(TlsProtocolHandler.AL_fatal, TlsProtocolHandler.AP_bad_record_mac);
+            }
+
+            byte[] plaintext = new byte[plaintextlength];
+            Array.Copy(ciphertext, offset, plaintext, 0, plaintextlength);
+            return plaintext;
+        }
+
+        private int ChooseExtraPadBlocks(Random r, int max)
+        {
+            int x = r.Next();
+            int n = LowestBitSet(x);
+            return Math.Min(n, max);
+        }
+
+        private int LowestBitSet(int x)
+        {
+            if (x == 0)
+            {
+                return 32;
+            }
+
+            int n = 0;
+            while ((x & 1) == 0)
+            {
+                ++n;
+                x >>= 1;
+            }
+            return n;
+        }
+    }
+}

--- a/extended-dotnet/TlsCipher.cs
+++ b/extended-dotnet/TlsCipher.cs
@@ -1,6 +1,10 @@
+using System.IO;
+
 namespace JRadius.Extended.Tls
 {
     public interface TlsCipher
     {
+        byte[] EncodePlaintext(short type, byte[] plaintext, int offset, int len);
+        byte[] DecodeCiphertext(short type, byte[] ciphertext, int offset, int len);
     }
 }

--- a/extended-dotnet/TlsDHKeyExchange.cs
+++ b/extended-dotnet/TlsDHKeyExchange.cs
@@ -1,0 +1,226 @@
+using Org.BouncyCastle.Asn1.X509;
+using Org.BouncyCastle.Crypto;
+using Org.BouncyCastle.Crypto.Agreement;
+using Org.BouncyCastle.Crypto.Generators;
+using Org.BouncyCastle.Crypto.IO;
+using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.Crypto.Utilities;
+using Org.BouncyCastle.Math;
+using Org.BouncyCastle.Security;
+using System;
+using System.IO;
+
+namespace JRadius.Extended.Tls
+{
+    public class TlsDHKeyExchange : TlsKeyExchange
+    {
+        private static readonly BigInteger ONE = BigInteger.One;
+        private static readonly BigInteger TWO = BigInteger.Two;
+
+        private readonly TlsProtocolHandler _handler;
+        private readonly CertificateVerifyer _verifyer;
+        private readonly short _keyExchange;
+        private readonly ITlsSigner _tlsSigner;
+
+        private AsymmetricKeyParameter _serverPublicKey = null;
+        private DHPublicKeyParameters _dhAgreeServerPublicKey = null;
+        private AsymmetricCipherKeyPair _dhAgreeClientKeyPair = null;
+
+        public TlsDHKeyExchange(TlsProtocolHandler handler, CertificateVerifyer verifyer, short keyExchange)
+        {
+            switch (keyExchange)
+            {
+                case TlsKeyExchange.KE_DH_RSA:
+                case TlsKeyExchange.KE_DH_DSS:
+                    _tlsSigner = null;
+                    break;
+                case TlsKeyExchange.KE_DHE_RSA:
+                    _tlsSigner = new TlsRSASigner();
+                    break;
+                case TlsKeyExchange.KE_DHE_DSS:
+                    _tlsSigner = new TlsDSSSigner();
+                    break;
+                default:
+                    throw new ArgumentException("unsupported key exchange algorithm");
+            }
+
+            _handler = handler;
+            _verifyer = verifyer;
+            _keyExchange = keyExchange;
+        }
+
+        public void SkipServerCertificate()
+        {
+            _handler.FailWithError(TlsProtocolHandler.AL_fatal, TlsProtocolHandler.AP_unexpected_message);
+        }
+
+        public void ProcessServerCertificate(Certificate serverCertificate)
+        {
+            var x509Cert = serverCertificate.Certs[0];
+            var keyInfo = x509Cert.SubjectPublicKeyInfo;
+
+            try
+            {
+                _serverPublicKey = PublicKeyFactory.CreateKey(keyInfo);
+            }
+            catch (Exception)
+            {
+                _handler.FailWithError(TlsProtocolHandler.AL_fatal, TlsProtocolHandler.AP_unsupported_certificate);
+            }
+
+            if (_serverPublicKey.IsPrivate)
+            {
+                _handler.FailWithError(TlsProtocolHandler.AL_fatal, TlsProtocolHandler.AP_internal_error);
+            }
+
+            switch (_keyExchange)
+            {
+                case TlsKeyExchange.KE_DH_DSS:
+                    if (!(_serverPublicKey is DHPublicKeyParameters))
+                    {
+                        _handler.FailWithError(TlsProtocolHandler.AL_fatal, TlsProtocolHandler.AP_certificate_unknown);
+                    }
+                    _dhAgreeServerPublicKey = ValidateDHPublicKey((DHPublicKeyParameters)_serverPublicKey);
+                    break;
+                case TlsKeyExchange.KE_DH_RSA:
+                    if (!(_serverPublicKey is DHPublicKeyParameters))
+                    {
+                        _handler.FailWithError(TlsProtocolHandler.AL_fatal, TlsProtocolHandler.AP_certificate_unknown);
+                    }
+                    _dhAgreeServerPublicKey = ValidateDHPublicKey((DHPublicKeyParameters)_serverPublicKey);
+                    break;
+                case TlsKeyExchange.KE_DHE_RSA:
+                    if (!(_serverPublicKey is RsaKeyParameters))
+                    {
+                        _handler.FailWithError(TlsProtocolHandler.AL_fatal, TlsProtocolHandler.AP_certificate_unknown);
+                    }
+                    ValidateKeyUsage(x509Cert, KeyUsage.DigitalSignature);
+                    break;
+                case TlsKeyExchange.KE_DHE_DSS:
+                    if (!(_serverPublicKey is DsaPublicKeyParameters))
+                    {
+                        _handler.FailWithError(TlsProtocolHandler.AL_fatal, TlsProtocolHandler.AP_certificate_unknown);
+                    }
+                    break;
+                default:
+                    _handler.FailWithError(TlsProtocolHandler.AL_fatal, TlsProtocolHandler.AP_unsupported_certificate);
+                    break;
+            }
+
+            if (!_verifyer.IsValid(serverCertificate.GetCerts()))
+            {
+                _handler.FailWithError(TlsProtocolHandler.AL_fatal, TlsProtocolHandler.AP_user_canceled);
+            }
+        }
+
+        public void SkipServerKeyExchange()
+        {
+            if (_tlsSigner != null)
+            {
+                _handler.FailWithError(TlsProtocolHandler.AL_fatal, TlsProtocolHandler.AP_unexpected_message);
+            }
+        }
+
+        public void ProcessServerKeyExchange(Stream is_Renamed, SecurityParameters securityParameters)
+        {
+            if (_tlsSigner == null)
+            {
+                _handler.FailWithError(TlsProtocolHandler.AL_fatal, TlsProtocolHandler.AP_unexpected_message);
+            }
+
+            Stream sigIn = is_Renamed;
+            ISigner signer = null;
+
+            if (_tlsSigner != null)
+            {
+                signer = InitSigner(_tlsSigner, securityParameters);
+                sigIn = new SignerStream(is_Renamed, signer, null);
+            }
+
+            byte[] pBytes = TlsUtils.ReadOpaque16(sigIn);
+            byte[] gBytes = TlsUtils.ReadOpaque16(sigIn);
+            byte[] YsBytes = TlsUtils.ReadOpaque16(sigIn);
+
+            if (signer != null)
+            {
+                byte[] sigByte = TlsUtils.ReadOpaque16(is_Renamed);
+                if (!signer.VerifySignature(sigByte))
+                {
+                    _handler.FailWithError(TlsProtocolHandler.AL_fatal, TlsProtocolHandler.AP_bad_certificate);
+                }
+            }
+
+            var p = new BigInteger(1, pBytes);
+            var g = new BigInteger(1, gBytes);
+            var Ys = new BigInteger(1, YsBytes);
+
+            _dhAgreeServerPublicKey = ValidateDHPublicKey(new DHPublicKeyParameters(Ys, new DHParameters(p, g)));
+        }
+
+        public byte[] GenerateClientKeyExchange()
+        {
+            var dhGen = new DHBasicKeyPairGenerator();
+            dhGen.Init(new DHKeyGenerationParameters(new SecureRandom(), _dhAgreeServerPublicKey.Parameters));
+            _dhAgreeClientKeyPair = dhGen.GenerateKeyPair();
+            var Yc = ((DHPublicKeyParameters)_dhAgreeClientKeyPair.Public).Y;
+            return Yc.ToByteArrayUnsigned();
+        }
+
+        public byte[] GeneratePremasterSecret()
+        {
+            var dhAgree = new DHBasicAgreement();
+            dhAgree.Init(_dhAgreeClientKeyPair.Private);
+            var agreement = dhAgree.CalculateAgreement(_dhAgreeServerPublicKey);
+            return agreement.ToByteArrayUnsigned();
+        }
+
+        private void ValidateKeyUsage(X509CertificateStructure c, int keyUsageBits)
+        {
+            var exts = c.TbsCertificate.Extensions;
+            if (exts != null)
+            {
+                var ext = exts.GetExtension(X509Extensions.KeyUsage);
+                if (ext != null)
+                {
+                    var ku = KeyUsage.GetInstance(ext);
+                    int bits = ku.GetBytes()[0] & 0xff;
+                    if ((bits & keyUsageBits) != keyUsageBits)
+                    {
+                        _handler.FailWithError(TlsProtocolHandler.AL_fatal, TlsProtocolHandler.AP_certificate_unknown);
+                    }
+                }
+            }
+        }
+
+        private ISigner InitSigner(ITlsSigner tlsSigner, SecurityParameters securityParameters)
+        {
+            var signer = tlsSigner.CreateVerifyer(_serverPublicKey);
+            signer.BlockUpdate(securityParameters.ClientRandom, 0, securityParameters.ClientRandom.Length);
+            signer.BlockUpdate(securityParameters.ServerRandom, 0, securityParameters.ServerRandom.Length);
+            return signer;
+        }
+
+        private DHPublicKeyParameters ValidateDHPublicKey(DHPublicKeyParameters key)
+        {
+            var Y = key.Y;
+            var parameters = key.Parameters;
+            var p = parameters.P;
+            var g = parameters.G;
+
+            if (!p.IsProbablePrime(2))
+            {
+                _handler.FailWithError(TlsProtocolHandler.AL_fatal, TlsProtocolHandler.AP_illegal_parameter);
+            }
+            if (g.CompareTo(TWO) < 0 || g.CompareTo(p.Subtract(TWO)) > 0)
+            {
+                _handler.FailWithError(TlsProtocolHandler.AL_fatal, TlsProtocolHandler.AP_illegal_parameter);
+            }
+            if (Y.CompareTo(TWO) < 0 || Y.CompareTo(p.Subtract(ONE)) > 0)
+            {
+                _handler.FailWithError(TlsProtocolHandler.AL_fatal, TlsProtocolHandler.AP_illegal_parameter);
+            }
+
+            return key;
+        }
+    }
+}

--- a/extended-dotnet/TlsDSSSigner.cs
+++ b/extended-dotnet/TlsDSSSigner.cs
@@ -1,0 +1,25 @@
+using Org.BouncyCastle.Crypto;
+using Org.BouncyCastle.Crypto.Digests;
+using Org.BouncyCastle.Crypto.Signers;
+
+namespace JRadius.Extended.Tls
+{
+    public class TlsDSSSigner : ITlsSigner
+    {
+        public byte[] CalculateRawSignature(AsymmetricKeyParameter privateKey, byte[] md5andsha1)
+        {
+            // Note: Only use the SHA1 part of the hash
+            ISigner sig = new DsaDigestSigner(new DsaSigner(), new NullDigest());
+            sig.Init(true, privateKey);
+            sig.BlockUpdate(md5andsha1, 16, 20);
+            return sig.GenerateSignature();
+        }
+
+        public ISigner CreateVerifyer(AsymmetricKeyParameter publicKey)
+        {
+            ISigner s = new DsaDigestSigner(new DsaSigner(), new Sha1Digest());
+            s.Init(false, publicKey);
+            return s;
+        }
+    }
+}

--- a/extended-dotnet/TlsKeyExchange.cs
+++ b/extended-dotnet/TlsKeyExchange.cs
@@ -4,11 +4,24 @@ namespace JRadius.Extended.Tls
 {
     public interface TlsKeyExchange
     {
+        const short KE_RSA = 1;
+        //    static final short KE_RSA_EXPORT = 2;
+        const short KE_DHE_DSS = 3;
+        //    static final short KE_DHE_DSS_EXPORT = 4;
+        const short KE_DHE_RSA = 5;
+        //    static final short KE_DHE_RSA_EXPORT = 6;
+        const short KE_DH_DSS = 7;
+        const short KE_DH_RSA = 8;
+        //    static final short KE_DH_anon = 9;
+        const short KE_SRP = 10;
+        const short KE_SRP_DSS = 11;
+        const short KE_SRP_RSA = 12;
+
+        void SkipServerCertificate();
         void ProcessServerCertificate(Certificate serverCertificate);
         void SkipServerKeyExchange();
+        void ProcessServerKeyExchange(Stream is_Renamed, SecurityParameters securityParameters);
         byte[] GenerateClientKeyExchange();
         byte[] GeneratePremasterSecret();
-        void SkipServerCertificate();
-        void ProcessServerKeyExchange(Stream stream, SecurityParameters securityParameters);
     }
 }

--- a/extended-dotnet/TlsMac.cs
+++ b/extended-dotnet/TlsMac.cs
@@ -1,0 +1,43 @@
+using Org.BouncyCastle.Crypto;
+using Org.BouncyCastle.Crypto.Macs;
+using Org.BouncyCastle.Crypto.Parameters;
+using System.IO;
+
+namespace JRadius.Extended.Tls
+{
+    public class TlsMac
+    {
+        private long _seqNo;
+        private readonly HMac _mac;
+
+        public TlsMac(IDigest digest, byte[] keyBlock, int offset, int len)
+        {
+            _mac = new HMac(digest);
+            var param = new KeyParameter(keyBlock, offset, len);
+            _mac.Init(param);
+            _seqNo = 0;
+        }
+
+        public int GetSize()
+        {
+            return _mac.GetMacSize();
+        }
+
+        public byte[] CalculateMac(short type, byte[] message, int offset, int len)
+        {
+            var bosMac = new MemoryStream(13);
+            TlsUtils.WriteUint64(_seqNo++, bosMac);
+            TlsUtils.WriteUint8(type, bosMac);
+            TlsUtils.WriteVersion(bosMac);
+            TlsUtils.WriteUint16(len, bosMac);
+
+            var macHeader = bosMac.ToArray();
+            _mac.BlockUpdate(macHeader, 0, macHeader.Length);
+            _mac.BlockUpdate(message, offset, len);
+
+            var result = new byte[_mac.GetMacSize()];
+            _mac.DoFinal(result, 0);
+            return result;
+        }
+    }
+}

--- a/extended-dotnet/TlsNullCipherSuite.cs
+++ b/extended-dotnet/TlsNullCipherSuite.cs
@@ -1,0 +1,32 @@
+using System;
+using System.IO;
+
+namespace JRadius.Extended.Tls
+{
+    public class TlsNullCipherSuite : TlsCipherSuite
+    {
+        protected override void Init(byte[] ms, byte[] cr, byte[] sr)
+        {
+            throw new TlsRuntimeException("Sorry, init of TLS_NULL_WITH_NULL_NULL is forbidden");
+        }
+
+        protected override byte[] EncodePlaintext(short type, byte[] plaintext, int offset, int len)
+        {
+            byte[] result = new byte[len];
+            Array.Copy(plaintext, offset, result, 0, len);
+            return result;
+        }
+
+        protected override byte[] DecodeCiphertext(short type, byte[] plaintext, int offset, int len, TlsProtocolHandler handler)
+        {
+            byte[] result = new byte[len];
+            Array.Copy(plaintext, offset, result, 0, len);
+            return result;
+        }
+
+        protected override short GetKeyExchangeAlgorithm()
+        {
+            return 0;
+        }
+    }
+}

--- a/extended-dotnet/TlsRSAKeyExchange.cs
+++ b/extended-dotnet/TlsRSAKeyExchange.cs
@@ -1,0 +1,128 @@
+using Org.BouncyCastle.Asn1.X509;
+using Org.BouncyCastle.Crypto;
+using Org.BouncyCastle.Crypto.Encodings;
+using Org.BouncyCastle.Crypto.Engines;
+using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.Security;
+using System;
+using System.IO;
+
+namespace JRadius.Extended.Tls
+{
+    public class TlsRSAKeyExchange : TlsKeyExchange
+    {
+        private readonly TlsProtocolHandler _handler;
+        private readonly CertificateVerifyer _verifyer;
+
+        private AsymmetricKeyParameter _serverPublicKey = null;
+        private RsaKeyParameters _rsaServerPublicKey = null;
+        private byte[] _premasterSecret;
+
+        public TlsRSAKeyExchange(TlsProtocolHandler handler, CertificateVerifyer verifyer)
+        {
+            _handler = handler;
+            _verifyer = verifyer;
+        }
+
+        public void SkipServerCertificate()
+        {
+            _handler.FailWithError(TlsProtocolHandler.AL_fatal, TlsProtocolHandler.AP_unexpected_message);
+        }
+
+        public void ProcessServerCertificate(Certificate serverCertificate)
+        {
+            var x509Cert = serverCertificate.Certs[0];
+            var keyInfo = x509Cert.SubjectPublicKeyInfo;
+
+            try
+            {
+                _serverPublicKey = PublicKeyFactory.CreateKey(keyInfo);
+            }
+            catch (Exception)
+            {
+                _handler.FailWithError(TlsProtocolHandler.AL_fatal, TlsProtocolHandler.AP_unsupported_certificate);
+            }
+
+            if (_serverPublicKey.IsPrivate)
+            {
+                _handler.FailWithError(TlsProtocolHandler.AL_fatal, TlsProtocolHandler.AP_internal_error);
+            }
+
+            if (!(_serverPublicKey is RsaKeyParameters))
+            {
+                _handler.FailWithError(TlsProtocolHandler.AL_fatal, TlsProtocolHandler.AP_certificate_unknown);
+            }
+            ValidateKeyUsage(x509Cert, KeyUsage.KeyEncipherment);
+            _rsaServerPublicKey = ValidateRSAPublicKey((RsaKeyParameters)_serverPublicKey);
+
+            if (!_verifyer.IsValid(serverCertificate.GetCerts()))
+            {
+                _handler.FailWithError(TlsProtocolHandler.AL_fatal, TlsProtocolHandler.AP_user_canceled);
+            }
+        }
+
+        public void SkipServerKeyExchange()
+        {
+            // OK
+        }
+
+        public void ProcessServerKeyExchange(Stream is_Renamed, SecurityParameters securityParameters)
+        {
+            _handler.FailWithError(TlsProtocolHandler.AL_fatal, TlsProtocolHandler.AP_unexpected_message);
+        }
+
+        public byte[] GenerateClientKeyExchange()
+        {
+            _premasterSecret = new byte[48];
+            _handler.Random.NextBytes(_premasterSecret);
+            TlsUtils.WriteVersion(_premasterSecret, 0);
+
+            var encoding = new Pkcs1Encoding(new RsaBlindedEngine());
+            encoding.Init(true, new ParametersWithRandom(_rsaServerPublicKey, _handler.Random));
+
+            try
+            {
+                return encoding.ProcessBlock(_premasterSecret, 0, _premasterSecret.Length);
+            }
+            catch (InvalidCipherTextException)
+            {
+                _handler.FailWithError(TlsProtocolHandler.AL_fatal, TlsProtocolHandler.AP_internal_error);
+                return null; // Unreachable!
+            }
+        }
+
+        public byte[] GeneratePremasterSecret()
+        {
+            byte[] tmp = _premasterSecret;
+            _premasterSecret = null;
+            return tmp;
+        }
+
+        private void ValidateKeyUsage(X509CertificateStructure c, int keyUsageBits)
+        {
+            var exts = c.TbsCertificate.Extensions;
+            if (exts != null)
+            {
+                var ext = exts.GetExtension(X509Extensions.KeyUsage);
+                if (ext != null)
+                {
+                    var ku = KeyUsage.GetInstance(ext);
+                    int bits = ku.GetBytes()[0] & 0xff;
+                    if ((bits & keyUsageBits) != keyUsageBits)
+                    {
+                        _handler.FailWithError(TlsProtocolHandler.AL_fatal, TlsProtocolHandler.AP_certificate_unknown);
+                    }
+                }
+            }
+        }
+
+        private RsaKeyParameters ValidateRSAPublicKey(RsaKeyParameters key)
+        {
+            if (!key.Exponent.IsProbablePrime(2))
+            {
+                _handler.FailWithError(TlsProtocolHandler.AL_fatal, TlsProtocolHandler.AP_illegal_parameter);
+            }
+            return key;
+        }
+    }
+}

--- a/extended-dotnet/TlsRSASigner.cs
+++ b/extended-dotnet/TlsRSASigner.cs
@@ -1,0 +1,27 @@
+using Org.BouncyCastle.Crypto;
+using Org.BouncyCastle.Crypto.Digests;
+using Org.BouncyCastle.Crypto.Encodings;
+using Org.BouncyCastle.Crypto.Engines;
+using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.Crypto.Signers;
+
+namespace JRadius.Extended.Tls
+{
+    public class TlsRSASigner : ITlsSigner
+    {
+        public byte[] CalculateRawSignature(AsymmetricKeyParameter privateKey, byte[] md5andsha1)
+        {
+            ISigner sig = new GenericSigner(new Pkcs1Encoding(new RsaBlindedEngine()), new NullDigest());
+            sig.Init(true, privateKey);
+            sig.BlockUpdate(md5andsha1, 0, md5andsha1.Length);
+            return sig.GenerateSignature();
+        }
+
+        public ISigner CreateVerifyer(AsymmetricKeyParameter publicKey)
+        {
+            ISigner s = new GenericSigner(new Pkcs1Encoding(new RsaBlindedEngine()), new CombinedHash());
+            s.Init(false, publicKey);
+            return s;
+        }
+    }
+}

--- a/extended-dotnet/TlsRuntimeException.cs
+++ b/extended-dotnet/TlsRuntimeException.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace JRadius.Extended.Tls
+{
+    public class TlsRuntimeException : Exception
+    {
+        public TlsRuntimeException(string message)
+            : base(message)
+        {
+        }
+
+        public TlsRuntimeException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+    }
+}

--- a/extended-dotnet/TlsSRPKeyExchange.cs
+++ b/extended-dotnet/TlsSRPKeyExchange.cs
@@ -1,0 +1,201 @@
+using Org.BouncyCastle.Asn1.X509;
+using Org.BouncyCastle.Crypto;
+using Org.BouncyCastle.Crypto.Agreement.Srp;
+using Org.BouncyCastle.Crypto.Digests;
+using Org.BouncyCastle.Crypto.IO;
+using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.Math;
+using Org.BouncyCastle.Security;
+using System;
+using System.IO;
+
+namespace JRadius.Extended.Tls
+{
+    public class TlsSRPKeyExchange : TlsKeyExchange
+    {
+        private readonly TlsProtocolHandler _handler;
+        private readonly CertificateVerifyer _verifyer;
+        private readonly short _keyExchange;
+        private readonly ITlsSigner _tlsSigner;
+
+        private AsymmetricKeyParameter _serverPublicKey = null;
+
+        // TODO Need a way of providing these
+        private byte[] _srpIdentity = null;
+        private byte[] _srpPassword = null;
+
+        private byte[] _s = null;
+        private BigInteger _b = null;
+        private readonly Srp6Client _srpClient = new Srp6Client();
+
+        public TlsSRPKeyExchange(TlsProtocolHandler handler, CertificateVerifyer verifyer, short keyExchange)
+        {
+            switch (keyExchange)
+            {
+                case TlsKeyExchange.KE_SRP:
+                    _tlsSigner = null;
+                    break;
+                case TlsKeyExchange.KE_SRP_RSA:
+                    _tlsSigner = new TlsRSASigner();
+                    break;
+                case TlsKeyExchange.KE_SRP_DSS:
+                    _tlsSigner = new TlsDSSSigner();
+                    break;
+                default:
+                    throw new ArgumentException("unsupported key exchange algorithm");
+            }
+
+            _handler = handler;
+            _verifyer = verifyer;
+            _keyExchange = keyExchange;
+        }
+
+        public void SkipServerCertificate()
+        {
+            if (_tlsSigner != null)
+            {
+                _handler.FailWithError(TlsProtocolHandler.AL_fatal, TlsProtocolHandler.AP_unexpected_message);
+            }
+        }
+
+        public void ProcessServerCertificate(Certificate serverCertificate)
+        {
+            if (_tlsSigner == null)
+            {
+                _handler.FailWithError(TlsProtocolHandler.AL_fatal, TlsProtocolHandler.AP_unexpected_message);
+            }
+
+            var x509Cert = serverCertificate.Certs[0];
+            var keyInfo = x509Cert.SubjectPublicKeyInfo;
+
+            try
+            {
+                _serverPublicKey = PublicKeyFactory.CreateKey(keyInfo);
+            }
+            catch (Exception)
+            {
+                _handler.FailWithError(TlsProtocolHandler.AL_fatal, TlsProtocolHandler.AP_unsupported_certificate);
+            }
+
+            if (_serverPublicKey.IsPrivate)
+            {
+                _handler.FailWithError(TlsProtocolHandler.AL_fatal, TlsProtocolHandler.AP_internal_error);
+            }
+
+            switch (_keyExchange)
+            {
+                case TlsKeyExchange.KE_SRP_RSA:
+                    if (!(_serverPublicKey is RsaKeyParameters))
+                    {
+                        _handler.FailWithError(TlsProtocolHandler.AL_fatal, TlsProtocolHandler.AP_certificate_unknown);
+                    }
+                    ValidateKeyUsage(x509Cert, KeyUsage.DigitalSignature);
+                    break;
+                case TlsKeyExchange.KE_SRP_DSS:
+                    if (!(_serverPublicKey is DsaPublicKeyParameters))
+                    {
+                        _handler.FailWithError(TlsProtocolHandler.AL_fatal, TlsProtocolHandler.AP_certificate_unknown);
+                    }
+                    break;
+                default:
+                    _handler.FailWithError(TlsProtocolHandler.AL_fatal, TlsProtocolHandler.AP_unsupported_certificate);
+                    break;
+            }
+
+            if (!_verifyer.IsValid(serverCertificate.GetCerts()))
+            {
+                _handler.FailWithError(TlsProtocolHandler.AL_fatal, TlsProtocolHandler.AP_user_canceled);
+            }
+        }
+
+        public void SkipServerKeyExchange()
+        {
+            _handler.FailWithError(TlsProtocolHandler.AL_fatal, TlsProtocolHandler.AP_unexpected_message);
+        }
+
+        public void ProcessServerKeyExchange(Stream is_Renamed, SecurityParameters securityParameters)
+        {
+            Stream sigIn = is_Renamed;
+            ISigner signer = null;
+
+            if (_tlsSigner != null)
+            {
+                signer = InitSigner(_tlsSigner, securityParameters);
+                sigIn = new SignerStream(is_Renamed, signer, null);
+            }
+
+            byte[] nBytes = TlsUtils.ReadOpaque16(sigIn);
+            byte[] gBytes = TlsUtils.ReadOpaque16(sigIn);
+            byte[] sBytes = TlsUtils.ReadOpaque8(sigIn);
+            byte[] bBytes = TlsUtils.ReadOpaque16(sigIn);
+
+            if (signer != null)
+            {
+                byte[] sigByte = TlsUtils.ReadOpaque16(is_Renamed);
+                if (!signer.VerifySignature(sigByte))
+                {
+                    _handler.FailWithError(TlsProtocolHandler.AL_fatal, TlsProtocolHandler.AP_bad_certificate);
+                }
+            }
+
+            var n = new BigInteger(1, nBytes);
+            var g = new BigInteger(1, gBytes);
+            _s = sBytes;
+
+            try
+            {
+                _b = Srp6Utilities.ValidatePublicValue(n, new BigInteger(1, bBytes));
+            }
+            catch (CryptoException)
+            {
+                _handler.FailWithError(TlsProtocolHandler.AL_fatal, TlsProtocolHandler.AP_illegal_parameter);
+            }
+
+            _srpClient.Init(n, g, new Sha1Digest(), new SecureRandom());
+        }
+
+        public byte[] GenerateClientKeyExchange()
+        {
+            return _srpClient.GenerateClientCredentials(_s, _srpIdentity, _srpPassword).ToByteArrayUnsigned();
+        }
+
+        public byte[] GeneratePremasterSecret()
+        {
+            try
+            {
+                return _srpClient.CalculateSecret(_b).ToByteArrayUnsigned();
+            }
+            catch (CryptoException)
+            {
+                _handler.FailWithError(TlsProtocolHandler.AL_fatal, TlsProtocolHandler.AP_illegal_parameter);
+                return null;
+            }
+        }
+
+        private void ValidateKeyUsage(X509CertificateStructure c, int keyUsageBits)
+        {
+            var exts = c.TbsCertificate.Extensions;
+            if (exts != null)
+            {
+                var ext = exts.GetExtension(X509Extensions.KeyUsage);
+                if (ext != null)
+                {
+                    var ku = KeyUsage.GetInstance(ext);
+                    int bits = ku.GetBytes()[0] & 0xff;
+                    if ((bits & keyUsageBits) != keyUsageBits)
+                    {
+                        _handler.FailWithError(TlsProtocolHandler.AL_fatal, TlsProtocolHandler.AP_certificate_unknown);
+                    }
+                }
+            }
+        }
+
+        private ISigner InitSigner(ITlsSigner tlsSigner, SecurityParameters securityParameters)
+        {
+            var signer = tlsSigner.CreateVerifyer(_serverPublicKey);
+            signer.BlockUpdate(securityParameters.ClientRandom, 0, securityParameters.ClientRandom.Length);
+            signer.BlockUpdate(securityParameters.ServerRandom, 0, securityParameters.ServerRandom.Length);
+            return signer;
+        }
+    }
+}


### PR DESCRIPTION
… .NET 8, focusing on the `net.jradius.tls` package from the `extended` module.

Here are the specific changes I made:

1.  **Extended Module (TLS Package):**
    *   Converted the `TlsCipherSuite` abstract class.
    *   Converted the `TlsNullCipherSuite` class.
    *   Converted the `TlsRuntimeException` class.
    *   Converted the `TlsMac` class.
    *   Converted the `TlsBlockCipher` class.
    *   Converted the `TlsCipher` interface.
    *   Converted the `CombinedHash` class.
    *   Converted the `ITlsSigner` interface and its implementations `TlsRSASigner` and `TlsDSSSigner`.
    *   Converted the `TlsKeyExchange` interface and its implementations `TlsDHKeyExchange`, `TlsRSAKeyExchange`, and `TlsSRPKeyExchange`.

**Work In Progress:**
I'm still working on converting the `extended` module. My next steps are to continue converting the classes within the `handler`, `radsec`, and `webservice` packages. The `core` module also has remaining classes in the `packet` and `server` packages that I will need to address. The overall task remains large, but this is another step towards a complete C# version of the library.