### PR TITLE
I am continuing the conversion of the JRadius library from Java to C#…

### DIFF
--- a/apps-dotnet/RadBench.cs
+++ b/apps-dotnet/RadBench.cs
@@ -1,0 +1,192 @@
+using JRadius.Core.Client;
+using JRadius.Core.Client.Auth;
+using JRadius.Core.Packet;
+using JRadius.Core.Packet.Attribute;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Threading;
+
+namespace JRadius.Apps
+{
+    public class RadBench
+    {
+        protected static RadiusClient client;
+        protected static IRadiusAuthenticator auth;
+
+        protected static void Usage()
+        {
+            Console.WriteLine("RadBench Arguments: [options] server secret file");
+            Console.WriteLine("\tserver\t\t= RADIUS server hostname or ip");
+            Console.WriteLine("\tsecret\t\t= Shared secret to use");
+            Console.WriteLine("\tfile\t\t= File containing the attribute name/value pairs");
+            Console.WriteLine("\nOptions:");
+            Console.WriteLine("\t-d java-class\t= Java class name of the attribute dictionary");
+            Console.WriteLine("\t                 (default: net.jradius.dictionary.RadiusDictionaryImpl)");
+            Console.WriteLine("\t-a auth-mode\t= Either PAP (default), CHAP, MSCHAP, MSCHAPv2,");
+            Console.WriteLine("\t                 EAP-MD5, or EAP-MSCHAPv2");
+            Console.WriteLine("\t                 (always provide the plain-text password in User-Password)");
+        }
+
+        protected static bool LoadAttributes(AttributeList list, StreamReader reader)
+        {
+            string line;
+            bool allowLine = true;
+
+            while ((line = reader.ReadLine()) != null)
+            {
+                line = line.Trim();
+                if (line.StartsWith("#")) continue;
+
+                if (string.IsNullOrEmpty(line))
+                {
+                    if (!allowLine) break;
+                    continue;
+                }
+
+                if (line.StartsWith("sleep "))
+                {
+                    allowLine = true;
+                    try
+                    {
+                        int i = int.Parse(line.Substring(6));
+                        if (i > 0) Thread.Sleep(i * 1000);
+                    }
+                    catch (Exception)
+                    {
+                        Console.WriteLine("Invalid sleep parameter");
+                    }
+                    continue;
+                }
+
+                allowLine = false;
+
+                try
+                {
+                    // TODO: Implement attribute parsing from string
+                }
+                catch (Exception)
+                {
+                    Console.WriteLine("Invalid radius attribute");
+                }
+            }
+
+            return (line != null);
+        }
+
+        public static void Main(string[] args)
+        {
+            // Manual argument parsing
+            var dictClass = "JRadius.Dictionary.AttributeDictionaryImpl";
+            var authPort = 1812;
+            var acctPort = 1813;
+            var timeout = 60;
+            var requesters = 5;
+            var requests = 10;
+            string host = null;
+            string secret = null;
+            string file = null;
+
+            var arguments = new Queue<string>(args);
+            while (arguments.Count > 0)
+            {
+                var arg = arguments.Dequeue();
+                // TODO: Implement argument parsing
+            }
+
+            if (host == null || secret == null || file == null)
+            {
+                Usage();
+                return;
+            }
+
+            // TODO: The C# version of AttributeFactory is not yet complete.
+            // AttributeFactory.LoadAttributeDictionary(dictClass);
+
+            try
+            {
+                var inet = Dns.GetHostEntry(host);
+                // TODO: The RadiusClient class has not been converted yet.
+                // client = new RadiusClient(inet.AddressList[0], secret, authPort, acctPort, timeout);
+
+                var threads = new BenchThread[requesters];
+                int i = 0;
+
+                Console.WriteLine("Starting Requester Threads...");
+                var startTime = DateTime.Now;
+
+                for (i = 0; i < requesters; i++)
+                {
+                    threads[i] = new BenchThread(requests, file);
+                    threads[i].Start();
+                }
+
+                int sent = 0;
+                int received = 0;
+
+                for (i = 0; i < threads.Length; i++)
+                {
+                    threads[i].Join();
+                    sent += threads[i].GetSent();
+                    received += threads[i].GetReceived();
+                }
+
+                var endTime = DateTime.Now;
+                Console.WriteLine("Completed.");
+                Console.WriteLine("Results:");
+                Console.WriteLine($"\tRequesters:       {requesters}");
+                Console.WriteLine($"\tRequests:         {requests}");
+                Console.WriteLine($"\tPackets Sent:     {sent}");
+                Console.WriteLine($"\tPackets Received: {received}");
+                Console.WriteLine($"\tSeconds:         {(endTime - startTime).TotalSeconds}");
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+            }
+        }
+
+        private class BenchThread : Thread
+        {
+            private readonly int _requests;
+            private readonly string _file;
+            private int _sent = 0;
+            private int _received = 0;
+
+            public BenchThread(int requests, string file)
+            {
+                _requests = requests;
+                _file = file;
+                IsBackground = true;
+            }
+
+            public override void Run()
+            {
+                try
+                {
+                    RunRequester();
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine(e);
+                }
+            }
+
+            public void RunRequester()
+            {
+                // TODO: Implement this method
+            }
+
+            public int GetReceived()
+            {
+                return _received;
+            }
+
+            public int GetSent()
+            {
+                return _sent;
+            }
+        }
+    }
+}

--- a/apps-dotnet/RadClient.cs
+++ b/apps-dotnet/RadClient.cs
@@ -1,0 +1,112 @@
+using JRadius.Core.Client;
+using JRadius.Core.Client.Auth;
+using JRadius.Core.Packet;
+using JRadius.Core.Packet.Attribute;
+using JRadius.Core.Standard;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Threading;
+
+namespace JRadius.Apps
+{
+    public class RadClient
+    {
+        private static RadiusClient client;
+
+        private static void Usage()
+        {
+            Console.WriteLine("\nRadClient Arguments: [options] server secret file");
+            Console.WriteLine("\tserver\t\t= RADIUS server hostname or ip");
+            Console.WriteLine("\tsecret\t\t= Shared secret to use");
+            Console.WriteLine("\tfile\t\t= File containing the attribute name/value pairs");
+            Console.WriteLine("\nOptions:");
+            Console.WriteLine("\t-d java-class\t= Java class name of the attribute dictionary");
+            Console.WriteLine("\t                 (default: net.jradius.dictionary.RadiusDictionaryImpl)");
+            Console.WriteLine("\t-s java-class\t= Java class name of the attribute checker");
+            Console.WriteLine("\t                 (e.g net.jradius.standard.WISPrStandard)");
+            Console.WriteLine("\t-a auth-mode\t= Either PAP (default), CHAP, MSCHAP, MSCHAPv2,");
+            Console.WriteLine("\t                 EAP-MD5, EAP-MSCHAPv2, or EAP-TLS (see below for format)");
+            Console.WriteLine("\t                 (provide the plain-text password in User-Password)");
+            Console.WriteLine("\t-T tunnel-mode\t= Only EAP-TTLS is currently supported (see below for info)");
+            Console.WriteLine("\t-A\t\t= Generate a unique Acct-Session-Id in Accounting Requests");
+            Console.WriteLine("\t-C\t\t= Turn OFF Class attribute support");
+            Console.WriteLine("\nUsing EAP-TLS and EAP-TTLS:");
+            Console.WriteLine("\nMore information at http://jradius.net/\n");
+        }
+
+        private static bool LoadAttributes(AttributeList list, StreamReader reader)
+        {
+            // Same as in RadBench
+            return false;
+        }
+
+        public static void Main(string[] args)
+        {
+            // Manual argument parsing
+            var dictClass = "JRadius.Dictionary.AttributeDictionaryImpl";
+            string check = null;
+            IRadiusAuthenticator auth = null;
+            var authPort = 1812;
+            var acctPort = 1813;
+            var timeout = 60;
+            bool tunneledRequest = false;
+            bool generateSessionId = false;
+            string host = null;
+            string secret = null;
+            string file = null;
+
+            var arguments = new Queue<string>(args);
+            while (arguments.Count > 0)
+            {
+                var arg = arguments.Dequeue();
+                // TODO: Implement argument parsing
+            }
+
+            if (host == null || secret == null || file == null)
+            {
+                Usage();
+                return;
+            }
+
+            // TODO: The C# version of AttributeFactory is not yet complete.
+            // AttributeFactory.LoadAttributeDictionary(dictClass);
+
+            try
+            {
+                var active = true;
+                var inet = Dns.GetHostEntry(host);
+                var reader = new StreamReader(file);
+                IRadiusStandard standard = null;
+
+                // TODO: The RadiusClient class has not been converted yet.
+                // client = new RadiusClient(inet.AddressList[0], secret, authPort, acctPort, timeout);
+
+                if (check != null)
+                {
+                    var c = Type.GetType(check);
+                    try
+                    {
+                        standard = (IRadiusStandard)Activator.CreateInstance(c);
+                    }
+                    catch (Exception e)
+                    {
+                        Console.WriteLine(e);
+                    }
+                }
+
+                RadiusAttribute classAttr = null;
+
+                while (active)
+                {
+                    // TODO: Implement the main loop
+                }
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+            }
+        }
+    }
+}

--- a/client-dotnet/IRadiusClientTransport.cs
+++ b/client-dotnet/IRadiusClientTransport.cs
@@ -1,0 +1,25 @@
+using JRadius.Core.Packet;
+using System.Net;
+
+namespace JRadius.Core.Client
+{
+    public interface IRadiusClientTransport
+    {
+        void SetRadiusClient(RadiusClient client);
+        RadiusResponse SendReceive(RadiusRequest p, int retries);
+        void Send(RadiusRequest p, int attempt);
+        void Close();
+        int GetAcctPort();
+        void SetAcctPort(int acctPort);
+        int GetAuthPort();
+        void SetAuthPort(int authPort);
+        int GetSocketTimeout();
+        void SetSocketTimeout(int socketTimeout);
+        IPAddress GetRemoteInetAddress();
+        void SetRemoteInetAddress(IPAddress remoteInetAddress);
+        IPAddress GetLocalInetAddress();
+        void SetLocalInetAddress(IPAddress localInetAddress);
+        string GetSharedSecret();
+        void SetSharedSecret(string sharedSecret);
+    }
+}

--- a/client-dotnet/ITransportStatusListener.cs
+++ b/client-dotnet/ITransportStatusListener.cs
@@ -1,0 +1,12 @@
+using JRadius.Core.Packet;
+
+namespace JRadius.Core.Client
+{
+    public interface ITransportStatusListener
+    {
+        void OnBeforeReceive(RadiusClientTransport transport);
+        void OnAfterReceive(RadiusClientTransport transport, RadiusPacket packet);
+        void OnBeforeSend(RadiusClientTransport transport, RadiusPacket packet);
+        void OnAfterSend(RadiusClientTransport transport);
+    }
+}

--- a/client-dotnet/RadiusClient.cs
+++ b/client-dotnet/RadiusClient.cs
@@ -1,0 +1,148 @@
+using JRadius.Core.Client.Auth;
+using JRadius.Core.Packet;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Sockets;
+
+namespace JRadius.Core.Client
+{
+    public class RadiusClient
+    {
+        protected IRadiusClientTransport _transport;
+        protected static readonly Dictionary<string, Type> _authenticators = new Dictionary<string, Type>();
+
+        static RadiusClient()
+        {
+            // TODO: Register authenticators
+        }
+
+        public RadiusClient()
+        {
+            _transport = new UdpClientTransport();
+            _transport.SetRadiusClient(this);
+        }
+
+        public RadiusClient(UdpClient socket)
+        {
+            _transport = new UdpClientTransport(socket);
+            _transport.SetRadiusClient(this);
+        }
+
+        public RadiusClient(IRadiusClientTransport transport)
+        {
+            _transport = transport;
+            _transport.SetRadiusClient(this);
+        }
+
+        public RadiusClient(IPAddress address, string secret)
+            : this()
+        {
+            SetRemoteInetAddress(address);
+            SetSharedSecret(secret);
+        }
+
+        public RadiusClient(UdpClient socket, IPAddress address, string secret)
+            : this(socket)
+        {
+            SetRemoteInetAddress(address);
+            SetSharedSecret(secret);
+        }
+
+        public RadiusClient(IPAddress address, string secret, int authPort, int acctPort, int timeout)
+            : this()
+        {
+            SetRemoteInetAddress(address);
+            SetSharedSecret(secret);
+            SetAuthPort(authPort);
+            SetAcctPort(acctPort);
+            SetSocketTimeout(timeout);
+        }
+
+        public RadiusClient(UdpClient socket, IPAddress address, string secret, int authPort, int acctPort, int timeout)
+            : this(socket)
+        {
+            SetRemoteInetAddress(address);
+            SetSharedSecret(secret);
+            SetAuthPort(authPort);
+            SetAcctPort(acctPort);
+            SetSocketTimeout(timeout);
+        }
+
+        public void Close()
+        {
+            _transport?.Close();
+        }
+
+        public static void RegisterAuthenticator(string name, Type c)
+        {
+            _authenticators[name] = c;
+        }
+
+        public static void RegisterAuthenticator(string name, string className)
+        {
+            var c = Type.GetType(className);
+            _authenticators[name] = c;
+        }
+
+        public int GetAcctPort()
+        {
+            return _transport.GetAcctPort();
+        }
+
+        public void SetAcctPort(int acctPort)
+        {
+            _transport.SetAcctPort(acctPort);
+        }
+
+        public int GetAuthPort()
+        {
+            return _transport.GetAuthPort();
+        }
+
+        public void SetAuthPort(int authPort)
+        {
+            _transport.SetAuthPort(authPort);
+        }
+
+        public int GetSocketTimeout()
+        {
+            return _transport.GetSocketTimeout();
+        }
+
+        public void SetSocketTimeout(int socketTimeout)
+        {
+            _transport.SetSocketTimeout(socketTimeout);
+        }
+
+        public IPAddress GetRemoteInetAddress()
+        {
+            return _transport.GetRemoteInetAddress();
+        }
+
+        public void SetRemoteInetAddress(IPAddress remoteInetAddress)
+        {
+            _transport.SetRemoteInetAddress(remoteInetAddress);
+        }
+
+        public IPAddress GetLocalInetAddress()
+        {
+            return _transport.GetLocalInetAddress();
+        }
+
+        public void SetLocalInetAddress(IPAddress localInetAddress)
+        {
+            // TODO: create a socket bound to the localInetAddress
+        }
+
+        public string GetSharedSecret()
+        {
+            return _transport.GetSharedSecret();
+        }
+
+        public void SetSharedSecret(string sharedSecret)
+        {
+            _transport.SetSharedSecret(sharedSecret);
+        }
+    }
+}

--- a/client-dotnet/RadiusClientSession.cs
+++ b/client-dotnet/RadiusClientSession.cs
@@ -1,0 +1,191 @@
+using JRadius.Core.Client.Auth;
+using JRadius.Core.Packet.Attribute;
+using System;
+using System.Threading;
+
+namespace JRadius.Core.Client
+{
+    public class RadiusClientSession : IDisposable
+    {
+        private RadiusClient _radiusClient;
+
+        private long _octetsIn;
+        private long _octetsOut;
+        private long _packetsIn;
+        private long _packetsOut;
+        private long _sessionTime;
+
+        private long _idleTimeout;
+        private long _sessionTimeout;
+        private long _interimInterval;
+
+        private bool _authenticated = false;
+        private bool _stopped = false;
+        private RadiusAttribute _classAttribute;
+        private IRadiusAuthenticator _radiusAuthenticator;
+        private Timer _timer;
+
+        public void Run()
+        {
+            // This will be called by the timer
+        }
+
+        public void Start()
+        {
+            if (_authenticated)
+            {
+                _timer = new Timer(s => Run(), null, 0, _interimInterval * 1000);
+            }
+        }
+
+        public void Stop()
+        {
+            _stopped = true;
+            _timer?.Dispose();
+        }
+
+        public void Dispose()
+        {
+            Stop();
+        }
+
+        public void IncrementOctetsIn(long l)
+        {
+            Interlocked.Add(ref _octetsIn, l);
+        }
+
+        public void IncrementOctetsOut(long l)
+        {
+            Interlocked.Add(ref _octetsOut, l);
+        }
+
+        public void IncrementPacketsIn(long l)
+        {
+            Interlocked.Add(ref _packetsIn, l);
+        }
+
+        public void IncrementPacketsOut(long l)
+        {
+            Interlocked.Add(ref _packetsOut, l);
+        }
+
+        public class RadiusClientSessionException : Exception
+        {
+            public RadiusClientSessionException(string s)
+                : base(s)
+            {
+            }
+        }
+
+        // Getters and Setters
+        public RadiusAttribute GetClassAttribute()
+        {
+            return _classAttribute;
+        }
+
+        public void SetClassAttribute(RadiusAttribute classAttribute)
+        {
+            _classAttribute = classAttribute;
+        }
+
+        public long GetIdleTimeout()
+        {
+            return _idleTimeout;
+        }
+
+        public void SetIdleTimeout(long idleTimeout)
+        {
+            _idleTimeout = idleTimeout;
+        }
+
+        public long GetInterimInterval()
+        {
+            return _interimInterval;
+        }
+
+        public void SetInterimInterval(long interimInterval)
+        {
+            _interimInterval = interimInterval;
+        }
+
+        public long GetOctetsIn()
+        {
+            return _octetsIn;
+        }
+
+        public void SetOctetsIn(long octetsIn)
+        {
+            _octetsIn = octetsIn;
+        }
+
+        public long GetOctetsOut()
+        {
+            return _octetsOut;
+        }
+
+        public void SetOctetsOut(long octetsOut)
+        {
+            _octetsOut = octetsOut;
+        }
+
+        public long GetPacketsIn()
+        {
+            return _packetsIn;
+        }
+
+        public void SetPacketsIn(long packetsIn)
+        {
+            _packetsIn = packetsIn;
+        }
+
+        public long GetPacketsOut()
+        {
+            return _packetsOut;
+        }
+
+        public void SetPacketsOut(long packetsOut)
+        {
+            _packetsOut = packetsOut;
+        }
+
+        public IRadiusAuthenticator GetRadiusAuthenticator()
+        {
+            return _radiusAuthenticator;
+        }
+
+        public void SetRadiusAuthenticator(IRadiusAuthenticator radiusAuthenticator)
+        {
+            _radiusAuthenticator = radiusAuthenticator;
+        }
+
+        public RadiusClient GetRadiusClient()
+        {
+            return _radiusClient;
+        }
+
+        public void SetRadiusClient(RadiusClient radiusClient)
+        {
+            _radiusClient = radiusClient;
+        }
+
+        public long GetSessionTime()
+        {
+            return _sessionTime;
+        }
+
+        public void SetSessionTime(long sessionTime)
+        {
+            _sessionTime = sessionTime;
+        }
+
+        public long GetSessionTimeout()
+        {
+            return _sessionTimeout;
+        }
+
+        public void SetSessionTimeout(long sessionTimeout)
+        {
+            _sessionTimeout = sessionTimeout;
+        }
+    }
+}

--- a/client-dotnet/RadiusClientTransport.cs
+++ b/client-dotnet/RadiusClientTransport.cs
@@ -1,0 +1,96 @@
+using JRadius.Core.Packet;
+using System.Net;
+
+namespace JRadius.Core.Client
+{
+    public abstract class RadiusClientTransport : IRadiusClientTransport
+    {
+        protected IPAddress LocalInetAddress;
+        protected IPAddress RemoteInetAddress;
+        protected string SharedSecret;
+
+        protected int AuthPort;
+        protected int AcctPort;
+
+        public const int DefaultTimeout = 60;
+        protected int SocketTimeout = DefaultTimeout * 1000;
+
+        protected RadiusClient _radiusClient;
+
+        protected abstract void Send(RadiusRequest req, int attempt);
+        protected abstract RadiusResponse Receive(RadiusRequest req);
+
+        public abstract void Close();
+
+        public RadiusResponse SendReceive(RadiusRequest p, int retries)
+        {
+            // TODO: Implement this method
+            return null;
+        }
+
+        public int GetAcctPort()
+        {
+            return AcctPort;
+        }
+
+        public void SetAcctPort(int acctPort)
+        {
+            AcctPort = acctPort;
+        }
+
+        public int GetAuthPort()
+        {
+            return AuthPort;
+        }
+
+        public void SetAuthPort(int authPort)
+        {
+            AuthPort = authPort;
+        }
+
+        public int GetSocketTimeout()
+        {
+            return SocketTimeout / 1000;
+        }
+
+        public virtual void SetSocketTimeout(int socketTimeout)
+        {
+            SocketTimeout = socketTimeout * 1000;
+        }
+
+        public IPAddress GetRemoteInetAddress()
+        {
+            return RemoteInetAddress;
+        }
+
+        public void SetRemoteInetAddress(IPAddress remoteInetAddress)
+        {
+            RemoteInetAddress = remoteInetAddress;
+        }
+
+        public IPAddress GetLocalInetAddress()
+        {
+            return LocalInetAddress;
+        }
+
+        public void SetLocalInetAddress(IPAddress localInetAddress)
+        {
+            LocalInetAddress = localInetAddress;
+        }
+
+        public string GetSharedSecret()
+        {
+            return SharedSecret;
+        }
+
+        public void SetSharedSecret(string sharedSecret)
+        {
+            SharedSecret = sharedSecret;
+        }
+
+        public void SetRadiusClient(RadiusClient client)
+        {
+            _radiusClient = client;
+        }
+    }
+}

--- a/client-dotnet/RadiusMultiClient.cs
+++ b/client-dotnet/RadiusMultiClient.cs
@@ -1,0 +1,48 @@
+using Microsoft.Extensions.Caching.Memory;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+
+namespace JRadius.Core.Client
+{
+    public class RadiusMultiClient : RadiusClient
+    {
+        private IMemoryCache _requestCache;
+
+        public RadiusMultiClient(IMemoryCache requestCache)
+            : base()
+        {
+            _requestCache = requestCache;
+        }
+
+        public RadiusMultiClient(IMemoryCache requestCache, UdpClient socket, IPAddress address, string secret, int authPort, int acctPort, int timeout)
+            : base(socket, address, secret, authPort, acctPort, timeout)
+        {
+            _requestCache = requestCache;
+        }
+
+        public RadiusMultiClient(IMemoryCache requestCache, UdpClient socket, IPAddress address, string secret)
+            : base(socket, address, secret)
+        {
+            _requestCache = requestCache;
+        }
+
+        public RadiusMultiClient(IMemoryCache requestCache, IPAddress address, string secret, int authPort, int acctPort, int timeout)
+            : base(address, secret, authPort, acctPort, timeout)
+        {
+            _requestCache = requestCache;
+        }
+
+        public RadiusMultiClient(IMemoryCache requestCache, IPAddress address, string secret)
+            : base(address, secret)
+        {
+            _requestCache = requestCache;
+        }
+
+        public RadiusMultiClient(IMemoryCache requestCache, IRadiusClientTransport transport)
+            : base(transport)
+        {
+            _requestCache = requestCache;
+        }
+    }
+}

--- a/client-dotnet/UdpClientTransport.cs
+++ b/client-dotnet/UdpClientTransport.cs
@@ -1,0 +1,58 @@
+using JRadius.Core.Packet;
+using System;
+using System.Net;
+using System.Net.Sockets;
+
+namespace JRadius.Core.Client
+{
+    public class UdpClientTransport : RadiusClientTransport
+    {
+        private static readonly RadiusFormat _format = RadiusFormat.GetInstance();
+        public const int DefaultAuthPort = 1812;
+        public const int DefaultAcctPort = 1813;
+
+        private UdpClient _socket;
+
+        public UdpClientTransport()
+        {
+            _socket = new UdpClient();
+        }
+
+        public UdpClientTransport(UdpClient socket)
+        {
+            _socket = socket;
+        }
+
+        public override void Close()
+        {
+            _socket?.Close();
+        }
+
+        protected override void Send(RadiusRequest req, int attempt)
+        {
+            var port = req is AccountingRequest ? AcctPort : AuthPort;
+            if (attempt > 1)
+            {
+                // TODO: Log retry
+            }
+
+            // TODO: Implement packet packing
+            var buffer = new byte[4096];
+            _socket.Send(buffer, buffer.Length, new IPEndPoint(RemoteInetAddress, port));
+        }
+
+        protected override RadiusResponse Receive(RadiusRequest req)
+        {
+            var remoteEP = new IPEndPoint(IPAddress.Any, 0);
+            var replyBytes = _socket.Receive(ref remoteEP);
+            // TODO: Implement packet parsing
+            return null;
+        }
+
+        public override void SetSocketTimeout(int timeout)
+        {
+            base.SetSocketTimeout(timeout);
+            _socket.Client.ReceiveTimeout = SocketTimeout;
+        }
+    }
+}

--- a/client-dotnet/auth/IRadiusAuthenticator.cs
+++ b/client-dotnet/auth/IRadiusAuthenticator.cs
@@ -1,0 +1,12 @@
+using JRadius.Core.Packet;
+
+namespace JRadius.Core.Client.Auth
+{
+    public interface IRadiusAuthenticator
+    {
+        string GetAuthName();
+        void SetupRequest(RadiusClient client, RadiusPacket p);
+        void ProcessRequest(RadiusPacket p);
+        void ProcessChallenge(RadiusPacket request, RadiusPacket challenge);
+    }
+}

--- a/core-dotnet/handler/PacketHandlerBase.cs
+++ b/core-dotnet/handler/PacketHandlerBase.cs
@@ -1,0 +1,33 @@
+using JRadius.Core.Config;
+using JRadius.Core.Server;
+
+namespace JRadius.Core.Handler
+{
+    public abstract class PacketHandlerBase : IJRCommand
+    {
+        protected ConfigurationItem _config;
+
+        public string Name => _config.Name;
+
+        public virtual bool DoesHandle(JRadiusEvent @event)
+        {
+            return true;
+        }
+
+        public virtual bool Execute(Chain.IContext context)
+        {
+            if (context is JRadiusRequest jRequest)
+            {
+                return Handle(jRequest);
+            }
+            return false;
+        }
+
+        public abstract bool Handle(JRadiusRequest jRequest);
+
+        public virtual void SetConfig(ConfigurationItem cfg)
+        {
+            _config = cfg;
+        }
+    }
+}

--- a/example-dotnet/ExampleRadiusClient.cs
+++ b/example-dotnet/ExampleRadiusClient.cs
@@ -1,0 +1,43 @@
+using JRadius.Core.Packet;
+using JRadius.Core.Packet.Attribute;
+using System;
+using System.Net;
+
+namespace JRadius.Example
+{
+    public class ExampleRadiusClient
+    {
+        public static void Main(string[] args)
+        {
+            try
+            {
+                // TODO: The C# version of AttributeFactory is not yet complete.
+                // AttributeFactory.LoadAttributeDictionary("JRadius.Dictionary.AttributeDictionaryImpl");
+
+                var host = Dns.GetHostEntry("localhost");
+                // TODO: The RadiusClient class has not been converted yet.
+                // var rc = new RadiusClient(host.AddressList[0], "test", 1812, 1813, 1000);
+
+                var attrs = new AttributeList();
+                // TODO: The attribute classes have not been converted yet.
+                // attrs.Add(new Attr_UserName("test"));
+                // attrs.Add(new Attr_NASPortType(Attr_NASPortType.Wireless80211));
+                // attrs.Add(new Attr_NASPort(1L));
+
+                // var request = new AccessRequest(rc, attrs);
+                // request.AddAttribute(new Attr_UserPassword("test"));
+
+                // Console.WriteLine("Sending:\n" + request.ToString());
+
+                // TODO: The MSCHAPv2Authenticator class has not been converted yet.
+                // var reply = rc.Authenticate((AccessRequest)request, new MSCHAPv2Authenticator(), 5);
+
+                // Console.WriteLine("Received:\n" + reply.ToString());
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+            }
+        }
+    }
+}

--- a/example-dotnet/LocalUsersHandler.cs
+++ b/example-dotnet/LocalUsersHandler.cs
@@ -1,0 +1,115 @@
+using JRadius.Core.Config;
+using JRadius.Core.Handler;
+using JRadius.Core.Packet;
+using JRadius.Core.Packet.Attribute;
+using JRadius.Core.Server;
+using System.Collections.Generic;
+using System.IO;
+using System.Xml.Linq;
+
+namespace JRadius.Example
+{
+    public class LocalUsersHandler : PacketHandlerBase
+    {
+        private class LocalUser
+        {
+            public string Username;
+            public string Realm;
+            public string Password;
+            public string Attributes;
+            public AttributeList AttrList;
+
+            public string GetUserName()
+            {
+                if (Realm != null) return $"{Username}@{Realm}";
+                return Username;
+            }
+
+            public AttributeList GetAttributeList()
+            {
+                if (AttrList == null)
+                {
+                    if (Attributes != null)
+                    {
+                        var reader = new StringReader(Attributes);
+                        string line;
+                        AttrList = new AttributeList();
+                        while ((line = reader.ReadLine()) != null)
+                        {
+                            // TODO: Implement attribute parsing from string
+                        }
+                    }
+                }
+                return AttrList;
+            }
+        }
+
+        private readonly Dictionary<string, LocalUser> _users = new Dictionary<string, LocalUser>();
+
+        public override void SetConfig(ConfigurationItem cfg)
+        {
+            base.SetConfig(cfg);
+            var root = cfg.GetRoot();
+            var usersList = root.Elements("users");
+            foreach (var l in usersList)
+            {
+                var children = l.Elements("user");
+                foreach (var node in children)
+                {
+                    var user = new LocalUser
+                    {
+                        Username = node.Attribute("username")?.Value,
+                        Realm = node.Attribute("realm")?.Value,
+                        Password = node.Attribute("password")?.Value,
+                        Attributes = node.Value
+                    };
+                    // TODO: Log the configured user
+                    _users[user.GetUserName()] = user;
+                }
+            }
+        }
+
+        public override bool Handle(JRadiusRequest jRequest)
+        {
+            try
+            {
+                var type = jRequest.Type;
+                var ci = jRequest.GetConfigItems();
+                var req = jRequest.GetRequestPacket();
+                var rep = jRequest.GetReplyPacket();
+
+                var username = req.GetAttributeValue(1); // User-Name
+                if (username == null)
+                {
+                    return false;
+                }
+
+                if (!_users.TryGetValue(username.ToString(), out var u))
+                {
+                    // Unknown username
+                    return false;
+                }
+
+                switch (type)
+                {
+                    case JRadiusServer.JRADIUS_AUTHORIZE:
+                        // TODO: Add attributes to the config items
+                        break;
+                    case JRadiusServer.JRADIUS_POST_AUTH:
+                        if (rep is AccessAccept)
+                        {
+                            // TODO: Add attributes to the reply
+                        }
+                        break;
+                }
+            }
+            catch (System.Exception)
+            {
+                // TODO: Log exception
+            }
+
+            jRequest.SetReturnValue(JRadiusServer.RLM_MODULE_UPDATED);
+            return false;
+        }
+    }
+}

--- a/example-dotnet/WPACaptivePortal.cs
+++ b/example-dotnet/WPACaptivePortal.cs
@@ -1,0 +1,54 @@
+using JRadius.Core.Handler;
+using JRadius.Core.Packet;
+using JRadius.Core.Packet.Attribute;
+using JRadius.Core.Server;
+
+namespace JRadius.Example
+{
+    public class WPACaptivePortal : PacketHandlerBase
+    {
+        public override bool Handle(JRadiusRequest request)
+        {
+            try
+            {
+                var ci = request.GetConfigItems();
+                var req = request.GetRequestPacket();
+                var rep = request.GetReplyPacket();
+
+                var username = req.GetAttributeValue(1); // User-Name
+
+                if (rep is AccessAccept)
+                {
+                    // TODO: Log info
+                }
+                else
+                {
+                    // TODO: The attribute classes have not been converted yet.
+                    // if ("allow-wpa-guests".Equals(req.GetAttributeValue(Attr_ChilliSpotConfig.TYPE)))
+                    // {
+                    //     if (req.FindAttribute(Attr_EAPMessage.TYPE) != null)
+                    //     {
+                    //         if (req.FindAttribute(Attr_FreeRADIUSProxiedTo.TYPE) != null)
+                    //         {
+                    //             rep = new AccessAccept();
+                    //             rep.AddAttribute(new Attr_ChilliSpotConfig("require-uam-auth"));
+                    //             request.SetReplyPacket(rep);
+
+                    //             ci.Add(new Attr_AuthType("Accept"));
+                    //             request.SetReturnValue(JRadiusServer.RLM_MODULE_UPDATED);
+                    //             return true;
+                    //         }
+                    //     }
+                    // }
+                }
+            }
+            catch (System.Exception)
+            {
+                // TODO: Log exception
+            }
+
+            request.SetReturnValue(JRadiusServer.RLM_MODULE_UPDATED);
+            return false;
+        }
+    }
+}

--- a/extended-dotnet/AlwaysValidVerifyer.cs
+++ b/extended-dotnet/AlwaysValidVerifyer.cs
@@ -1,0 +1,19 @@
+using Org.BouncyCastle.Asn1.X509;
+
+namespace JRadius.Extended.Tls
+{
+    /// <summary>
+    /// A certificate verifyer, that will always return true.
+    /// DO NOT USE THIS FILE UNLESS YOU KNOW EXACTLY WHAT YOU ARE DOING.
+    /// </summary>
+    public class AlwaysValidVerifyer : ICertificateVerifyer
+    {
+        /// <summary>
+        /// Return true.
+        /// </summary>
+        public bool IsValid(X509CertificateStructure[] certs)
+        {
+            return true;
+        }
+    }
+}

--- a/extended-dotnet/CertificateVerifyer.cs
+++ b/extended-dotnet/CertificateVerifyer.cs
@@ -1,7 +1,0 @@
-namespace JRadius.Extended.Tls
-{
-    public interface CertificateVerifyer
-    {
-        bool IsValid(Certificate cert);
-    }
-}

--- a/extended-dotnet/ICertificateVerifyer.cs
+++ b/extended-dotnet/ICertificateVerifyer.cs
@@ -1,0 +1,9 @@
+using Org.BouncyCastle.Asn1.X509;
+
+namespace JRadius.Extended.Tls
+{
+    public interface ICertificateVerifyer
+    {
+        bool IsValid(X509CertificateStructure[] certs);
+    }
+}

--- a/extended-dotnet/TlsNullCipher.cs
+++ b/extended-dotnet/TlsNullCipher.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace JRadius.Extended.Tls
+{
+    public class TlsNullCipher : TlsCipher
+    {
+        public byte[] EncodePlaintext(short type, byte[] plaintext, int offset, int len)
+        {
+            return CopyData(plaintext, offset, len);
+        }
+
+        public byte[] DecodeCiphertext(short type, byte[] ciphertext, int offset, int len)
+        {
+            return CopyData(ciphertext, offset, len);
+        }
+
+        private byte[] CopyData(byte[] text, int offset, int len)
+        {
+            byte[] result = new byte[len];
+            Array.Copy(text, offset, result, 0, len);
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
… .NET 8. I have now done the initial conversion of the `example`, `apps`, and `client` modules.

Here are the changes I made:

1.  **`extras` Module Analysis:**
    *   I analyzed the `extras` module and, since it contains no source code, I am considering it complete for this phase.

2.  **`example` and `apps` Modules:**
    *   I converted the Java classes in the `example` and `apps` modules to C# skeletons. This includes `ExampleRadiusClient`, `LocalUsersHandler`, `WPACaptivePortal`, `RadBench`, and `RadClient`.
    *   These converted classes are currently skeletons because they have significant dependencies on other modules (like `client` and `core`) that I have not yet fully converted.

3.  **`client` Module Conversion:**
    *   I started converting the client API, which is sourced from the `core` module's `net.jradius.client` package, and placed the files in the `client-dotnet` project.
    *   I converted key classes such as `RadiusClient`, `RadiusClientTransport` (and its UDP implementation), `RadiusClientSession`, and `RadiusMultiClient`.
    *   I also began the conversion of the authentication sub-package by creating the `IRadiusAuthenticator` interface.

**Work In Progress:**
The conversion is ongoing. My immediate next steps for the `client` module will be to convert all the `RadiusAuthenticator` implementations. Following that, I will address the `server` and `ssl` modules. Many of the converted classes are still skeletons and will require their implementation details to be filled in as their dependencies are converted. The overall task remains large, and this work represents another step towards a complete C# version of the library.