### PR TITLE
This commit continues the conversion of the JRadius library from Java…

### DIFF
--- a/core-dotnet/JRadius.Core.csproj
+++ b/core-dotnet/JRadius.Core.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="8.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
… to C# .NET 8. It includes the implementation of an object pooling mechanism for RADIUS attributes and continues the conversion of the `client` and `server` modules.

The following changes have been made:

1.  **Attribute Object Pooling:**
    *   The `AttributeFactory` in `core-dotnet` has been updated to use `Microsoft.Extensions.ObjectPool` to manage `RadiusAttribute` instances.
    *   A custom `RadiusAttributePooledObjectPolicy` has been implemented to handle the creation of different attribute types.

2.  **`client` Module (Authenticators):**
    *   The conversion of the authentication protocols has continued with the implementation of `PAPAuthenticator`, `CHAPAuthenticator`, `MSCHAPv1Authenticator`, `MSCHAPv2Authenticator`, `EAPAuthenticator`, `EAPMD5Authenticator`, and `EAPMSCHAPv2Authenticator`.
    *   The `ITunnelAuthenticator` interface has been created.
    *   Numerous utility and attribute classes have been converted to support the authenticators, including a C# implementation of the MD4 hash algorithm.

3.  **`server` Module:**
    *   The conversion of the server-side components has begun with the implementation of `JRadiusThread`, `KeepAliveListener`, `TCPListener`, `IListener`, and the `RadiusProcessor` abstract base class.

**Work In Progress:**
The conversion is ongoing. The immediate next steps are to complete the implementation of the remaining authenticators in the `client` module, finish the `server` module by implementing the concrete `RadiusProcessor` and SSL logic, and then fill in the implementation details for the skeleton classes in all modules.