### PR TITLE
I'm continuing to convert your JRadius library from Java to C# .NET 8…

### DIFF
--- a/DHCPPacketGenerator/DHCPPacketGenerator.csproj
+++ b/DHCPPacketGenerator/DHCPPacketGenerator.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/DHCPPacketGenerator/Program.cs
+++ b/DHCPPacketGenerator/Program.cs
@@ -1,0 +1,68 @@
+using System;
+using System.IO;
+using System.Text.RegularExpressions;
+
+namespace DHCPPacketGenerator
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            if (args.Length < 2)
+            {
+                Console.WriteLine("Usage: DHCPPacketGenerator <javaSourcePath> <csharpOutputPath>");
+                return;
+            }
+
+            string javaSourcePath = args[0];
+            string csharpOutputPath = args[1];
+
+            if (!Directory.Exists(csharpOutputPath))
+            {
+                Directory.CreateDirectory(csharpOutputPath);
+            }
+
+            var javaFiles = Directory.GetFiles(javaSourcePath, "DHCP*.java");
+            var codeRegex = new Regex(@"public static final int CODE = (1024 \+ \d+);");
+
+            foreach (var javaFile in javaFiles)
+            {
+                var className = Path.GetFileNameWithoutExtension(javaFile);
+                if (className == "DHCPPacket" || className == "DHCPFormat")
+                {
+                    continue;
+                }
+
+                var content = File.ReadAllText(javaFile);
+                var match = codeRegex.Match(content);
+                if (match.Success)
+                {
+                    var code = match.Groups[1].Value;
+                    var csharpClass = $@"
+using JRadius.Core.Packet.Attribute;
+
+namespace JRadius.Core.Packet
+{{
+    public class {className} : DHCPPacket
+    {{
+        public const int CODE = {code};
+
+        public {className}()
+        {{
+            _code = CODE;
+        }}
+
+        public {className}(AttributeList attributes)
+            : base(attributes)
+        {{
+            _code = CODE;
+        }}
+    }}
+}}";
+                    File.WriteAllText(Path.Combine(csharpOutputPath, $"{className}.cs"), csharpClass);
+                    Console.WriteLine($"Generated {className}.cs");
+                }
+            }
+        }
+    }
+}

--- a/core-dotnet/packet/DHCPAck.cs
+++ b/core-dotnet/packet/DHCPAck.cs
@@ -1,0 +1,20 @@
+using JRadius.Core.Packet.Attribute;
+
+namespace JRadius.Core.Packet
+{
+    public class DHCPAck : DHCPPacket
+    {
+        public const int CODE = 1024 + 5;
+
+        public DHCPAck()
+        {
+            _code = CODE;
+        }
+
+        public DHCPAck(AttributeList attributes)
+            : base(attributes)
+        {
+            _code = CODE;
+        }
+    }
+}

--- a/core-dotnet/packet/DHCPDecline.cs
+++ b/core-dotnet/packet/DHCPDecline.cs
@@ -1,0 +1,20 @@
+using JRadius.Core.Packet.Attribute;
+
+namespace JRadius.Core.Packet
+{
+    public class DHCPDecline : DHCPPacket
+    {
+        public const int CODE = 1024 + 4;
+
+        public DHCPDecline()
+        {
+            _code = CODE;
+        }
+
+        public DHCPDecline(AttributeList attributes)
+            : base(attributes)
+        {
+            _code = CODE;
+        }
+    }
+}

--- a/core-dotnet/packet/DHCPDiscover.cs
+++ b/core-dotnet/packet/DHCPDiscover.cs
@@ -1,0 +1,12 @@
+namespace JRadius.Core.Packet
+{
+    public class DHCPDiscover : DHCPPacket
+    {
+        public const int CODE = 1024 + 1;
+
+        public DHCPDiscover()
+        {
+            _code = CODE;
+        }
+    }
+}

--- a/core-dotnet/packet/DHCPForceRenew.cs
+++ b/core-dotnet/packet/DHCPForceRenew.cs
@@ -1,0 +1,20 @@
+using JRadius.Core.Packet.Attribute;
+
+namespace JRadius.Core.Packet
+{
+    public class DHCPForceRenew : DHCPPacket
+    {
+        public const int CODE = 1024 + 9;
+
+        public DHCPForceRenew()
+        {
+            _code = CODE;
+        }
+
+        public DHCPForceRenew(AttributeList attributes)
+            : base(attributes)
+        {
+            _code = CODE;
+        }
+    }
+}

--- a/core-dotnet/packet/DHCPInform.cs
+++ b/core-dotnet/packet/DHCPInform.cs
@@ -1,0 +1,20 @@
+using JRadius.Core.Packet.Attribute;
+
+namespace JRadius.Core.Packet
+{
+    public class DHCPInform : DHCPPacket
+    {
+        public const int CODE = 1024 + 8;
+
+        public DHCPInform()
+        {
+            _code = CODE;
+        }
+
+        public DHCPInform(AttributeList attributes)
+            : base(attributes)
+        {
+            _code = CODE;
+        }
+    }
+}

--- a/core-dotnet/packet/DHCPNack.cs
+++ b/core-dotnet/packet/DHCPNack.cs
@@ -1,0 +1,20 @@
+using JRadius.Core.Packet.Attribute;
+
+namespace JRadius.Core.Packet
+{
+    public class DHCPNack : DHCPPacket
+    {
+        public const int CODE = 1024 + 6;
+
+        public DHCPNack()
+        {
+            _code = CODE;
+        }
+
+        public DHCPNack(AttributeList attributes)
+            : base(attributes)
+        {
+            _code = CODE;
+        }
+    }
+}

--- a/core-dotnet/packet/DHCPOffer.cs
+++ b/core-dotnet/packet/DHCPOffer.cs
@@ -1,0 +1,20 @@
+using JRadius.Core.Packet.Attribute;
+
+namespace JRadius.Core.Packet
+{
+    public class DHCPOffer : DHCPPacket
+    {
+        public const int CODE = 1024 + 2;
+
+        public DHCPOffer()
+        {
+            _code = CODE;
+        }
+
+        public DHCPOffer(AttributeList attributes)
+            : base(attributes)
+        {
+            _code = CODE;
+        }
+    }
+}

--- a/core-dotnet/packet/DHCPPacket.cs
+++ b/core-dotnet/packet/DHCPPacket.cs
@@ -1,0 +1,17 @@
+using JRadius.Core.Packet.Attribute;
+
+namespace JRadius.Core.Packet
+{
+    public abstract class DHCPPacket : RadiusPacket
+    {
+        public DHCPPacket()
+            : base()
+        {
+        }
+
+        public DHCPPacket(AttributeList attributes)
+            : base(attributes)
+        {
+        }
+    }
+}

--- a/core-dotnet/packet/DHCPRelease.cs
+++ b/core-dotnet/packet/DHCPRelease.cs
@@ -1,0 +1,20 @@
+using JRadius.Core.Packet.Attribute;
+
+namespace JRadius.Core.Packet
+{
+    public class DHCPRelease : DHCPPacket
+    {
+        public const int CODE = 1024 + 7;
+
+        public DHCPRelease()
+        {
+            _code = CODE;
+        }
+
+        public DHCPRelease(AttributeList attributes)
+            : base(attributes)
+        {
+            _code = CODE;
+        }
+    }
+}

--- a/core-dotnet/packet/DHCPRequest.cs
+++ b/core-dotnet/packet/DHCPRequest.cs
@@ -1,0 +1,20 @@
+using JRadius.Core.Packet.Attribute;
+
+namespace JRadius.Core.Packet
+{
+    public class DHCPRequest : DHCPPacket
+    {
+        public const int CODE = 1024 + 3;
+
+        public DHCPRequest()
+        {
+            _code = CODE;
+        }
+
+        public DHCPRequest(AttributeList attributes)
+            : base(attributes)
+        {
+            _code = CODE;
+        }
+    }
+}


### PR DESCRIPTION
…. This update covers the conversion of the DHCP packet classes.

Here's what I've done so far:

*   **DHCP Packet Classes:** I converted the `DHCPPacket` base class and its concrete implementations (`DHCPDiscover`, `DHCPOffer`, `DHCPAck`, `DHCPDecline`, `DHCPForceRenew`, `DHCPInform`, `DHCPNack`, `DHCPRelease`, `DHCPRequest`) from Java to C#.

**What's Next:**
I'm still working on converting the `packet` package. My next step is to convert the remaining packet types, such as `Password`. After the `packet` package is complete, I'll focus on finishing the `server` and `client` modules.