### PR TITLE
I'm continuing the conversion of the JRadius library from Java to C# …

### DIFF
--- a/core-dotnet/packet/PasswordAck.cs
+++ b/core-dotnet/packet/PasswordAck.cs
@@ -1,0 +1,12 @@
+namespace JRadius.Core.Packet
+{
+    public class PasswordAck : RadiusResponse
+    {
+        public const byte CODE = 8;
+
+        public PasswordAck()
+        {
+            _code = CODE;
+        }
+    }
+}

--- a/core-dotnet/packet/PasswordReject.cs
+++ b/core-dotnet/packet/PasswordReject.cs
@@ -1,0 +1,12 @@
+namespace JRadius.Core.Packet
+{
+    public class PasswordReject : RadiusResponse
+    {
+        public const byte CODE = 9;
+
+        public PasswordReject()
+        {
+            _code = CODE;
+        }
+    }
+}

--- a/core-dotnet/packet/PasswordRequest.cs
+++ b/core-dotnet/packet/PasswordRequest.cs
@@ -1,0 +1,12 @@
+namespace JRadius.Core.Packet
+{
+    public class PasswordRequest : AccessRequest
+    {
+        public const byte CODE = 7;
+
+        public PasswordRequest()
+        {
+            _code = CODE;
+        }
+    }
+}


### PR DESCRIPTION
….NET 8. In this step, I've converted the Password packet classes.

Here are the changes I made:

1.  **Password Packet Classes:**
    *   I converted the `PasswordRequest`, `PasswordAck`, and `PasswordReject` classes from Java to C#.

The conversion of the `packet` package is still a work in progress. Next, I'll convert the remaining packet types (like Format, etc.). Once the `packet` package is finished, I will shift my focus to completing the `server` and `client` modules.