### PR TITLE
I've continued the conversion of the JRadius library from Java to C# …

### DIFF
--- a/core-dotnet/packet/DiameterFormat.cs
+++ b/core-dotnet/packet/DiameterFormat.cs
@@ -1,0 +1,66 @@
+using JRadius.Core.Packet.Attribute;
+using System;
+using System.IO;
+
+namespace JRadius.Core.Packet
+{
+    public class DiameterFormat : Format
+    {
+        private const byte AVP_VENDOR = 0x80;
+
+        public override void PackAttribute(MemoryStream buffer, RadiusAttribute a)
+        {
+            var attributeValue = a.GetValue();
+            int length = attributeValue.GetLength();
+            int padding = ((length + 0x03) & ~0x03) - length;
+            PackHeader(buffer, a);
+            attributeValue.GetBytes(buffer);
+            while (padding-- > 0)
+            {
+                PutUnsignedByte(buffer, 0);
+            }
+        }
+
+        public void PackHeader(MemoryStream buffer, RadiusAttribute a)
+        {
+            if (a is VSAttribute vsa)
+            {
+                PackHeader(buffer, vsa);
+                return;
+            }
+
+            var attributeValue = a.GetValue();
+            PutUnsignedInt(buffer, a.GetType());
+            PutUnsignedByte(buffer, 0);
+            PutUnsignedByte(buffer, 0); // part of the AVP Length!
+            PutUnsignedShort(buffer, attributeValue.GetLength() + 8);
+        }
+
+        public void PackHeader(MemoryStream buffer, VSAttribute a)
+        {
+            var attributeValue = a.GetValue();
+            PutUnsignedInt(buffer, a.GetVsaAttributeType());
+            PutUnsignedByte(buffer, AVP_VENDOR);
+            PutUnsignedByte(buffer, 0); // part of the AVP Length!
+            PutUnsignedShort(buffer, attributeValue.GetLength() + 12);
+            PutUnsignedInt(buffer, a.GetVendorId());
+        }
+
+        public override void UnpackAttributeHeader(MemoryStream buffer, AttributeParseContext ctx)
+        {
+            ctx.AttributeType = (int)ReadUnsignedInt(buffer);
+            int flags = ReadUnsignedByte(buffer);
+            ReadUnsignedByte(buffer);
+            ctx.AttributeLength = ReadUnsignedShort(buffer);
+            ctx.HeaderLength = 8;
+
+            if ((flags & AVP_VENDOR) > 0)
+            {
+                ctx.VendorNumber = (int)ReadUnsignedInt(buffer);
+                ctx.HeaderLength += 4;
+            }
+
+            ctx.Padding = (int)(((ctx.AttributeLength + 0x03) & ~0x03) - ctx.AttributeLength);
+        }
+    }
+}

--- a/extended-dotnet/auth/EAPTTLSAuthenticator.cs
+++ b/extended-dotnet/auth/EAPTTLSAuthenticator.cs
@@ -1,0 +1,100 @@
+using JRadius.Core.Client;
+using JRadius.Core.Client.Auth;
+using JRadius.Core.Packet;
+using JRadius.Core.Packet.Attribute;
+using System.IO;
+
+namespace JRadius.Extended.Auth
+{
+    public class EAPTTLSAuthenticator : EAPTLSAuthenticator, ITunnelAuthenticator
+    {
+        public new const string NAME = "eap-ttls";
+        private string _innerProtocol = "pap";
+        private IRadiusAuthenticator _tunnelAuth;
+        private RadiusPacket _tunnelRequest;
+        private RadiusPacket _tunnelChallenge;
+        private AttributeList _tunneledAttributes;
+        private static readonly DiameterFormat _diameterFormat = new DiameterFormat();
+
+        public EAPTTLSAuthenticator()
+        {
+            SetEAPType(EAP_TTLS);
+        }
+
+        public override void Init()
+        {
+            base.Init();
+            _tunnelAuth = RadiusClient.GetAuthProtocol(GetInnerProtocol());
+            if (_tunnelAuth == null || _tunnelAuth is MSCHAPv2Authenticator || _tunnelAuth is MSCHAPv1Authenticator || _tunnelAuth is CHAPAuthenticator)
+            {
+                throw new System.Exception("You can not currently use " + _tunnelAuth.GetAuthName() + " within a TLS Tunnel because of limitations in Java 1.5.");
+            }
+        }
+
+        protected new bool IsCertificateRequired()
+        {
+            return false;
+        }
+
+        public override string GetAuthName()
+        {
+            return NAME;
+        }
+
+        public void SetTunneledAttributes(AttributeList attributes)
+        {
+            _tunneledAttributes = attributes;
+        }
+
+        public override void SetupRequest(RadiusClient client, RadiusPacket p)
+        {
+            base.SetupRequest(client, p);
+            _tunnelRequest = new AccessRequest(_tunneledAttributes);
+            var attrs = _tunnelRequest.GetAttributes();
+            // TODO: Implement attribute copying
+            _tunnelAuth.SetupRequest(client, _tunnelRequest);
+            if (!(_tunnelAuth is PAPAuthenticator))
+            {
+                _tunnelAuth.ProcessRequest(_tunnelRequest);
+            }
+        }
+
+        protected bool DoTunnelAuthentication(byte id, byte[] input)
+        {
+            if (_tunnelChallenge != null && input != null)
+            {
+                var list = _tunnelChallenge.GetAttributes();
+                list.Clear();
+                var buffer = new MemoryStream(input);
+                _diameterFormat.UnpackAttributes(list, buffer, (int)buffer.Length, false);
+                if (_tunnelAuth is EAPAuthenticator && _tunnelChallenge.FindAttribute(79) == null)
+                {
+                    _tunnelAuth.SetupRequest(_client, _tunnelRequest);
+                }
+                else
+                {
+                    _tunnelAuth.ProcessChallenge(_tunnelRequest, _tunnelChallenge);
+                }
+            }
+            else
+            {
+                _tunnelChallenge = new AccessChallenge();
+            }
+
+            var outBuffer = new MemoryStream(1500);
+            _diameterFormat.PackAttributeList(_tunnelRequest.GetAttributes(), outBuffer, true);
+            // TODO: PutAppBuffer(outBuffer.ToArray(), 0, (int)outBuffer.Position);
+            return true;
+        }
+
+        public string GetInnerProtocol()
+        {
+            return _innerProtocol;
+        }
+
+        public void SetInnerProtocol(string innerProtocol)
+        {
+            _innerProtocol = innerProtocol;
+        }
+    }
+}

--- a/extended-dotnet/auth/PEAPAuthenticator.cs
+++ b/extended-dotnet/auth/PEAPAuthenticator.cs
@@ -1,0 +1,60 @@
+using JRadius.Core.Client;
+using JRadius.Core.Client.Auth;
+using JRadius.Core.Packet;
+using JRadius.Core.Packet.Attribute;
+
+namespace JRadius.Extended.Auth
+{
+    public class PEAPAuthenticator : EAPTLSAuthenticator
+    {
+        public new const string NAME = "peap";
+        private EAPAuthenticator _tunnelAuth;
+        private RadiusPacket _tunnelRequest;
+
+        public PEAPAuthenticator()
+        {
+            SetEAPType(EAP_PEAP);
+        }
+
+        public override void Init()
+        {
+            base.Init();
+            _tunnelAuth = new EAPMSCHAPv2Authenticator(true);
+        }
+
+        public override string GetAuthName()
+        {
+            return NAME;
+        }
+
+        protected new bool IsCertificateRequired()
+        {
+            return false;
+        }
+
+        public override void SetupRequest(RadiusClient client, RadiusPacket p)
+        {
+            base.SetupRequest(client, p);
+            _tunnelRequest = new AccessRequest();
+            var attrs = _tunnelRequest.GetAttributes();
+            // TODO: Implement attribute copying
+            _tunnelAuth.SetupRequest(client, _tunnelRequest);
+            _tunnelAuth.ProcessRequest(_tunnelRequest);
+        }
+
+        protected bool DoTunnelAuthentication(byte id, byte[] input)
+        {
+            byte[] output;
+            if (input != null && input.Length > 0)
+            {
+                output = _tunnelAuth.DoEAP(input);
+            }
+            else
+            {
+                output = _tunnelAuth.EapResponse(EAP_IDENTITY, 0, GetUsername());
+            }
+            // TODO: PutAppBuffer(output);
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
….NET 8. This update includes my conversion of the tunneled EAP authenticators from the `extended` module.

Here are the changes I've made:

1.  **Tunneled EAP Authenticators:**
    *   I converted the `EAPTLSAuthenticator`, `EAPTTLSAuthenticator`, and `PEAPAuthenticator` classes from Java to C#.

2.  **Supporting Classes:**
    *   I converted the `KeyStoreUtil` class to C# to provide utilities for loading keys and certificates.
    *   I also converted the `DiameterFormat` class to support the EAP-TTLS authenticator.

**Next Steps:**
The `client` and `extended` modules are now substantially complete. I will now work on filling in the remaining implementation details in all modules, especially the `TODO` comments.